### PR TITLE
chore: mysql 버전 명시

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly "com.mysql:mysql-connector-j:8.4.0"
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'


### PR DESCRIPTION
mysql 버전에 따라 접속이 안되는 문제가 발생하여 버전 명시했습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * MySQL Connector/J 의존성이 명시적으로 버전 8.4.0으로 업데이트되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->