### PR TITLE
[BE] chore: MySQL 초기화 스크립트 실행 설정 추가

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - --collation-server=utf8mb4_unicode_ci
     volumes:
       - mysql_data:/var/lib/mysql
+      - ../docker/mysql/init:/docker-entrypoint-initdb.d/schema.sql
       - ../docker/mysql/init:/docker-entrypoint-initdb.d
 
 volumes:


### PR DESCRIPTION
## 😉 연관 이슈
Closes #30 
## 🚀 작업 내용
1. MySQL 컨테이너 실행 시 schema.sql이 자동 실행되도록 docker-compose.yml 설정 수정
2. 로컬의 backend/src/main/resources/sql/schema.sql 파일을 컨테이너 내부의 /docker-entrypoint-initdb.d/ 경로로 마운트
## 💬 리뷰 중점사항
볼륨 마운트 경로가 프로젝트 구조와 일치하는지 확인해주세요.
최초 실행 시 테이블이 정상적으로 생성되는지 각자의 환경에서도 확인 필요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * MySQL 데이터베이스 초기화 프로세스 개선으로 컨테이너 시작 시 스키마 스크립트가 자동으로 실행되도록 설정했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->