### PR TITLE
[BE] chore: Flyway 버전 중복 체크 자동화 스크립트 및 CI 설정 추가

### DIFF
--- a/.github/workflows/flyway-check.yml
+++ b/.github/workflows/flyway-check.yml
@@ -1,0 +1,27 @@
+name: Flyway Version Duplicate Check
+
+on:
+  pull_request:
+    paths:
+      - 'backend/src/main/resources/db/migration/**'
+
+jobs:
+  check-duplicate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check for duplicate Flyway versions
+        run: |
+          versions=$(ls backend/src/main/resources/db/migration/V*__*.sql | sed -re 's/.*\/V([0-9.]+)__.*/\1/' | sort)
+          
+          duplicates=$(echo "$versions" | uniq -d)
+          
+          if [ -n "$duplicates" ]; then
+            echo "❌: Flyway 버전이 중복되었습니다."
+            echo "$duplicates"
+            exit 1 # 에러를 발생시켜 CI 중단
+          else
+            echo "✅: 모든 버전 번호가 고유합니다."
+          fi


### PR DESCRIPTION
## 😉 연관 이슈
#37 
## 🚀 작업 내용
동시에 마이그레이션 파일을 생성할 때, Flyway 버전 번호가 중복되어 발생하는 배포 시점의 오류를 방지하기 위해 CI 자동화 로직을 도입

중복 체크 스크립트 작성: backend/src/main/resources/db/migration 디렉토리 내 파일명을 분석하여 중복된 버전(V{Number}__)이 있는지 검사하는 쉘 스크립트를 구현했습니다.

GitHub Actions 워크플로우 추가: PR이 생성되거나 업데이트될 때마다 위 스크립트가 실행되도록 설정했습니다.

CI 차단 로직: 중복이 발견될 경우 exit 1을 통해 빌드를 실패 처리하고, 어떤 버전이 중복되었는지 로그에 명시하여 즉각적인 수정이 가능하도록 했습니다.

## 💬 리뷰 중점사항
작성된 쉘 스크립트가 다양한 버전 명명 규칙(예: V1__, V1.1__)을 누락 없이 체크하는지 확인해 주세요.

CI 실패 시 출력되는 에러 메시지가 명확한지 검토해 주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 데이터베이스 마이그레이션 버전 중복을 자동으로 검사하는 검증 프로세스가 추가되었습니다. 이를 통해 마이그레이션 파일의 버전 충돌을 조기에 감지하고 예방할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->