### PR TITLE
[BE] feat: 알림 기능 확장 및 개선, 테스트

### DIFF
--- a/backend/src/main/java/back/domain/NotificationType.java
+++ b/backend/src/main/java/back/domain/NotificationType.java
@@ -1,0 +1,16 @@
+package back.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum NotificationType {
+    SCHEDULE("일정"),
+    POST("게시글"),
+    COMMENT("댓글"),
+    CLUB_WELCOME("모임 가입 환영"),
+    VOTE_DEADLINE("투표 마감 임박");
+
+    private final String description;
+}

--- a/backend/src/main/java/back/event/ClubJoinEvent.java
+++ b/backend/src/main/java/back/event/ClubJoinEvent.java
@@ -1,0 +1,13 @@
+package back.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ClubJoinEvent {
+    private final Long clubId;
+    private final Long memberId; // ClubMembers PK
+    private final Long userId; // Users PK
+    private final String clubName;
+}

--- a/backend/src/main/java/back/event/CommentCreatedEvent.java
+++ b/backend/src/main/java/back/event/CommentCreatedEvent.java
@@ -1,0 +1,13 @@
+package back.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CommentCreatedEvent {
+    private final Long postId;
+    private final String commentContent;
+    private final Long commentAuthorId; // 댓글 작성자
+    private final Long postAuthorId; // 게시글 작성자 (수신 대상)
+}

--- a/backend/src/main/java/back/event/PostCreatedEvent.java
+++ b/backend/src/main/java/back/event/PostCreatedEvent.java
@@ -5,9 +5,9 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public class ScheduleRegisteredEvent {
+public class PostCreatedEvent {
     private final Long clubId;
-    private final Long scheduleId;
-    private final String scheduleName;
+    private final Long postId;
+    private final String postTitle;
     private final Long authorId;
 }

--- a/backend/src/main/java/back/event/VoteDeadlineEvent.java
+++ b/backend/src/main/java/back/event/VoteDeadlineEvent.java
@@ -1,0 +1,16 @@
+package back.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class VoteDeadlineEvent {
+    private final Long voteId;
+    private final String voteTitle;
+    private final Long clubId; // 투표가 속한 모임 ID (Vote -> Schedule or Post -> Club) ... 복잡하지만 Vote 엔티티에 clubId 직접
+                               // 연관이 없음.
+    // Vote -> Schedule (있으면) -> Club
+    // Vote -> Post (있으면) -> Club
+    // 조회 시점에 clubId를 알아와서 넣어줘야 함.
+}

--- a/backend/src/main/java/back/listener/NotificationEventListener.java
+++ b/backend/src/main/java/back/listener/NotificationEventListener.java
@@ -1,7 +1,11 @@
 package back.listener;
 
+import back.domain.NotificationType;
 import back.domain.Notifications;
+import back.domain.club.ClubMembers;
 import back.dto.NotificationResponse;
+import back.event.CommentCreatedEvent;
+import back.event.PostCreatedEvent;
 import back.event.ScheduleRegisteredEvent;
 import back.repository.club.ClubMemberRepository;
 import back.repository.notifications.NotificationsRepository;
@@ -11,8 +15,8 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
@@ -24,27 +28,94 @@ public class NotificationEventListener {
 
     @Async
     @TransactionalEventListener
-    public void handleScheduleRegisteredEvent(ScheduleRegisteredEvent scheduleRegisteredEvent) {
-        //TODO : 활성화 상태인 멤버 리스트를 조회하는 로직으로 교체 필요
-        //더미 데이터
-        List<Long> memberIds = List.of(1L, 2L, 3L);
+    public void handleScheduleRegisteredEvent(ScheduleRegisteredEvent event) {
+        List<ClubMembers> members = clubMemberRepository.findByClubIdAndStatus(event.getClubId(),
+                ClubMembers.Status.ACTIVE);
 
-        List<Notifications> list = new ArrayList<>();
-        for (int i = 0; i < memberIds.size(); i++) {
-            list.add(new Notifications(
-                    memberIds.get(i),
-                    "새로운 일정 '" + scheduleRegisteredEvent.getScheduleName() + "'이 등록 되었습니다.",
-                    scheduleRegisteredEvent.getScheduleId(),
-                    "SCHEDULE"
-                    ));
+        List<Notifications> notifications = members.stream()
+                .filter(member -> !member.getUserId().equals(event.getAuthorId())) // 본인 제외
+                .map(member -> new Notifications(
+                        member.getUserId(),
+                        "새로운 일정 '" + event.getScheduleName() + "'이 등록 되었습니다.",
+                        event.getScheduleId(),
+                        NotificationType.SCHEDULE.name()))
+                .collect(Collectors.toList());
+
+        saveAndSend(notifications);
+    }
+
+    @Async
+    @TransactionalEventListener
+    public void handlePostCreatedEvent(PostCreatedEvent event) {
+        List<ClubMembers> members = clubMemberRepository.findByClubIdAndStatus(event.getClubId(),
+                ClubMembers.Status.ACTIVE);
+
+        List<Notifications> notifications = members.stream()
+                .filter(member -> !member.getUserId().equals(event.getAuthorId()))
+                .map(member -> new Notifications(
+                        member.getUserId(),
+                        "새로운 게시글 '" + event.getPostTitle() + "'이 등록 되었습니다.",
+                        event.getPostId(),
+                        NotificationType.POST.name()))
+                .collect(Collectors.toList());
+
+        saveAndSend(notifications);
+    }
+
+    @Async
+    @TransactionalEventListener
+    public void handleCommentCreatedEvent(CommentCreatedEvent event) {
+        if (event.getCommentAuthorId().equals(event.getPostAuthorId())) {
+            return; // 본인 글에 댓글 단 경우 알림 생략
         }
-        List<Notifications> notifications = notificationsRepository.saveAll(list);
 
-        for (Notifications notification : notifications) {
+        Notifications notification = new Notifications(
+                event.getPostAuthorId(),
+                "작성하신 게시글에 새로운 댓글이 달렸습니다: " + event.getCommentContent(),
+                event.getPostId(),
+                NotificationType.COMMENT.name());
+
+        saveAndSend(List.of(notification));
+    }
+
+    @Async
+    @TransactionalEventListener
+    public void handleClubJoinEvent(back.event.ClubJoinEvent event) {
+        // 1. 가입자 본인에게 승인 알림
+        Notifications welcomeNotification = new Notifications(
+                event.getUserId(),
+                "'" + event.getClubName() + "' 모임 가입이 승인되었습니다.",
+                event.getClubId(),
+                NotificationType.CLUB_WELCOME.name());
+        saveAndSend(List.of(welcomeNotification));
+    }
+
+    @Async
+    @TransactionalEventListener
+    public void handleVoteDeadlineEvent(back.event.VoteDeadlineEvent event) {
+        List<ClubMembers> members = clubMemberRepository.findByClubIdAndStatus(event.getClubId(),
+                ClubMembers.Status.ACTIVE);
+
+        List<Notifications> notifications = members.stream()
+                .map(member -> new Notifications(
+                        member.getUserId(),
+                        "투표 '" + event.getVoteTitle() + "' 마감이 1시간 남았습니다.",
+                        event.getVoteId(),
+                        NotificationType.VOTE_DEADLINE.name()))
+                .collect(Collectors.toList());
+
+        saveAndSend(notifications);
+    }
+
+    private void saveAndSend(List<Notifications> notifications) {
+        if (notifications.isEmpty())
+            return;
+
+        List<Notifications> savedNotifications = notificationsRepository.saveAll(notifications);
+
+        for (Notifications notification : savedNotifications) {
             NotificationResponse response = NotificationResponse.from(notification);
             notificationService.send(notification.getUserId(), response);
         }
-
-
     }
 }

--- a/backend/src/main/java/back/repository/vote/VoteRepository.java
+++ b/backend/src/main/java/back/repository/vote/VoteRepository.java
@@ -11,44 +11,49 @@ import java.util.Optional;
 
 public interface VoteRepository extends JpaRepository<Votes, Long> {
 
-    /**
-     * 기한이 지났지만 아직 종료되지 않은 일반 투표들을 조회합니다.
-     */
-    @Query("SELECT v FROM Votes v WHERE v.voteType = 'GENERAL' " +
-           "AND v.status = 'OPEN' " +
-           "AND v.deadline IS NOT NULL " +
-           "AND v.deadline <= :now")
-    List<Votes> findExpiredGeneralVotes(@Param("now") LocalDateTime now);
+       /**
+        * 기한이 지났지만 아직 종료되지 않은 일반 투표들을 조회합니다.
+        */
+       @Query("SELECT v FROM Votes v WHERE v.voteType = 'GENERAL' " +
+                     "AND v.status = 'OPEN' " +
+                     "AND v.deadline IS NOT NULL " +
+                     "AND v.deadline <= :now")
+       List<Votes> findExpiredGeneralVotes(@Param("now") LocalDateTime now);
 
-    /**
-     * 일정 시작 5분 전이 지났지만 아직 종료되지 않은 일정 투표들을 조회합니다.
-     */
-    @Query(value = "SELECT v.* FROM votes v " +
-           "INNER JOIN schedules s ON v.schedule_id = s.schedule_id " +
-           "WHERE v.vote_type = 'ATTENDANCE' " +
-           "AND v.status = 'OPEN' " +
-           "AND s.event_date IS NOT NULL " +
-           "AND DATE_SUB(s.event_date, INTERVAL 5 MINUTE) <= :now", 
-           nativeQuery = true)
-    List<Votes> findExpiredAttendanceVotes(@Param("now") LocalDateTime now);
+       /**
+        * 마감 시간이 특정 구간에 있는 투표들을 조회합니다.
+        */
+       @Query("SELECT v FROM Votes v WHERE v.status = 'OPEN' AND v.deadline BETWEEN :start AND :end")
+       List<Votes> findUpcomingDeadlines(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 
-    /**
-     * 특정 일정에 연결된 투표를 조회합니다.
-     */
-    Optional<Votes> findByScheduleId(Long scheduleId);
+       /**
+        * 일정 시작 5분 전이 지났지만 아직 종료되지 않은 일정 투표들을 조회합니다.
+        */
+       @Query(value = "SELECT v.* FROM votes v " +
+                     "INNER JOIN schedules s ON v.schedule_id = s.schedule_id " +
+                     "WHERE v.vote_type = 'ATTENDANCE' " +
+                     "AND v.status = 'OPEN' " +
+                     "AND s.event_date IS NOT NULL " +
+                     "AND DATE_SUB(s.event_date, INTERVAL 5 MINUTE) <= :now", nativeQuery = true)
+       List<Votes> findExpiredAttendanceVotes(@Param("now") LocalDateTime now);
 
-    /**
-     * postId 목록으로 투표들을 조회합니다.
-     */
-    List<Votes> findByPostIdIn(List<Long> postIds);
+       /**
+        * 특정 일정에 연결된 투표를 조회합니다.
+        */
+       Optional<Votes> findByScheduleId(Long scheduleId);
 
-    /**
-     * 특정 게시글에 연결된 투표를 조회합니다.
-     */
-    Optional<Votes> findByPostId(Long postId);
+       /**
+        * postId 목록으로 투표들을 조회합니다.
+        */
+       List<Votes> findByPostIdIn(List<Long> postIds);
 
-    /**
-     * 특정 일정에 연결된 투표들을 조회합니다.
-     */
-    List<Votes> findByScheduleIdIn(List<Long> scheduleIds);
+       /**
+        * 특정 게시글에 연결된 투표를 조회합니다.
+        */
+       Optional<Votes> findByPostId(Long postId);
+
+       /**
+        * 특정 일정에 연결된 투표들을 조회합니다.
+        */
+       List<Votes> findByScheduleIdIn(List<Long> scheduleIds);
 }

--- a/backend/src/main/java/back/service/club/ClubMemberService.java
+++ b/backend/src/main/java/back/service/club/ClubMemberService.java
@@ -18,6 +18,7 @@ public class ClubMemberService {
 
     private final ClubMemberRepository clubMemberRepository;
     private final ClubRepository clubRepository;
+    private final org.springframework.context.ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public ClubMemberResponse joinClub(Long clubId, Long userId, ClubMemberRequest request) {
@@ -62,6 +63,17 @@ public class ClubMemberService {
         }
 
         targetMember.approve();
+
+        // 클럽 정보 조회가 필요함 (이벤트를 위해)
+        Clubs club = clubRepository.findById(clubId).orElseThrow(ClubException.NotFound::new);
+
+        // 가입 환영 이벤트 발행
+        eventPublisher.publishEvent(new back.event.ClubJoinEvent(
+                clubId,
+                targetMember.getMemberId(),
+                targetMember.getUserId(),
+                club.getClubName()));
+
         return ClubMemberResponse.from(targetMember);
     }
 

--- a/backend/src/main/java/back/service/post/PostCommentService.java
+++ b/backend/src/main/java/back/service/post/PostCommentService.java
@@ -28,45 +28,57 @@ public class PostCommentService {
         private final UserRepository userRepository;
         private final PostRepository postRepository;
         private final ClubAuthService clubsAuthorizationService;
+        private final org.springframework.context.ApplicationEventPublisher eventPublisher;
 
+        @Transactional
         public PostCommentsIdResponse createComment(
                         Long writerId,
                         Long clubId,
                         Long postId,
                         PostCommentRequest request) {
-            clubsAuthorizationService.assertActiveMember(clubId, writerId);
-            Comments comments = postCommentRepository.save(buildPostComment(writerId, postId, request));
+                clubsAuthorizationService.assertActiveMember(clubId, writerId);
+                Comments comments = postCommentRepository.save(buildPostComment(writerId, postId, request));
 
-            return PostCommentsIdResponse.from(comments);
+                // 알림 이벤트 발행
+                eventPublisher.publishEvent(new back.event.CommentCreatedEvent(
+                                postId,
+                                comments.getContent(),
+                                writerId,
+                                comments.getPost().getWriter().getUserId()));
+
+                return PostCommentsIdResponse.from(comments);
         }
 
         @Transactional
         public PostCommentsIdResponse updateComment(Long writerId, Long clubId, Long postId, Long commentId,
                         PostCommentRequest request) {
-             clubsAuthorizationService.validateAndGetClubForUpdatePosts(clubId,writerId);
+                clubsAuthorizationService.validateAndGetClubForUpdatePosts(clubId, writerId);
 
-            Comments comment = postCommentRepository.findByCommentIdAndPost_PostIdAndPost_Club_ClubIdAndDeletedAtIsNull(commentId, postId, clubId)
-                    .orElseThrow(PostsException.PostCommentNotFound::new); // 예외는 댓글용으로 교체 권장
+                Comments comment = postCommentRepository
+                                .findByCommentIdAndPost_PostIdAndPost_Club_ClubIdAndDeletedAtIsNull(commentId, postId,
+                                                clubId)
+                                .orElseThrow(PostsException.PostCommentNotFound::new); // 예외는 댓글용으로 교체 권장
 
-            boolean isWriter = comment.getWriter().getUserId().equals(writerId); //
+                boolean isWriter = comment.getWriter().getUserId().equals(writerId); //
 
-             if (!isWriter) {
-                    clubsAuthorizationService.assertAtLeastManager(clubId, writerId);
-             }
+                if (!isWriter) {
+                        clubsAuthorizationService.assertAtLeastManager(clubId, writerId);
+                }
 
-            comment.updateContent(request.content()); // 엔티티 메서드
+                comment.updateContent(request.content()); // 엔티티 메서드
 
-            return PostCommentsIdResponse.from(comment);
+                return PostCommentsIdResponse.from(comment);
         }
 
         public PostCommentsResponse getPostComments(Long viewerId, Long clubId, Long postId, Pageable pageable) {
-                 clubsAuthorizationService.validateAndGetClubForReadPosts(clubId, viewerId);
+                clubsAuthorizationService.validateAndGetClubForReadPosts(clubId, viewerId);
 
                 Page<Comments> page = postCommentRepository
                                 .findAllByPost_PostIdAndPost_Club_ClubIdAndDeletedAtIsNull(
                                                 postId, clubId, pageable);
 
-                List<PostCommentsResponse.Item> items = page.getContent().stream().map(PostCommentsResponse.Item::from).toList();
+                List<PostCommentsResponse.Item> items = page.getContent().stream().map(PostCommentsResponse.Item::from)
+                                .toList();
 
                 return new PostCommentsResponse(
                                 items,
@@ -81,7 +93,8 @@ public class PostCommentService {
         public PostCommentsIdResponse deleteComment(Long actorId, Long clubId, Long postId, Long commentId) {
 
                 Comments comment = postCommentRepository
-                                .findByCommentIdAndPost_PostIdAndPost_Club_ClubIdAndDeletedAtIsNull(commentId, postId, clubId)
+                                .findByCommentIdAndPost_PostIdAndPost_Club_ClubIdAndDeletedAtIsNull(commentId, postId,
+                                                clubId)
                                 .orElseThrow(PostsException.PostCommentNotFound::new); // 프로젝트 예외로 교체
 
                 // 멱등 삭제
@@ -90,10 +103,10 @@ public class PostCommentService {
                 }
                 clubsAuthorizationService.validateAndGetClubForUpdatePosts(clubId, actorId);
 
-                 boolean isWriter = comment.getWriter().getUserId().equals(actorId);
-                 if (!isWriter) {
+                boolean isWriter = comment.getWriter().getUserId().equals(actorId);
+                if (!isWriter) {
                         clubsAuthorizationService.assertAtLeastManager(clubId, actorId);
-                 }
+                }
 
                 comment.delete(); // 엔티티 메서드에서 deletedAt 세팅
 

--- a/backend/src/main/java/back/service/post/PostService.java
+++ b/backend/src/main/java/back/service/post/PostService.java
@@ -48,14 +48,24 @@ public class PostService {
     private final PostImageRepository postImageRepository;
     private final PostMemberTagRepository postMemberTagRepository;
 
+    // 알림 전송을 위해 추가
+    private final org.springframework.context.ApplicationEventPublisher eventPublisher;
+
     @Transactional
     public PostIdResponse createStory(Long clubId, Long writerId, StoryCreateRequest request) {
 
-         clubAuthorizationService.assertActiveMember(clubId, writerId);
+        clubAuthorizationService.assertActiveMember(clubId, writerId);
 
         Posts saved = postRepository.save(buildStoryPost(clubId, writerId, request));
 
         applyOptionalUpdatesOnCreate(saved, request);
+
+        // 알림 이벤트 발행
+        eventPublisher.publishEvent(new back.event.PostCreatedEvent(
+                clubId,
+                saved.getPostId(),
+                saved.getContent(), /* 제목이 없으므로 내용 앞부분이나 전체 사용. 스토리형 게시글이라 제목 필드가 없는 모양 */
+                writerId));
 
         return PostIdResponse.from(saved);
     }
@@ -68,7 +78,7 @@ public class PostService {
         return PostDetailResponse.from(post);
     }
 
-    //스토리 페이지에 게시글 박스
+    // 스토리 페이지에 게시글 박스
     public List<PostCardResponse> getRecentPosts(Long clubId, Long viewerId, Pageable pageable) {
         clubAuthorizationService.validateAndGetClubForReadPosts(clubId, viewerId);
 
@@ -81,24 +91,23 @@ public class PostService {
         Map<Long, List<String>> imageMap = postIds.isEmpty()
                 ? Map.of()
                 : postImageRepository.findByPostIdIn(postIds).stream()
-                .collect(Collectors.groupingBy(
-                        PostImages::getPostId,
-                        Collectors.mapping(PostImages::getImageUrl, Collectors.toList())
-                ));
+                        .collect(Collectors.groupingBy(
+                                PostImages::getPostId,
+                                Collectors.mapping(PostImages::getImageUrl, Collectors.toList())));
 
         return page.getContent().stream()
                 .map(p -> PostCardResponse.of(p, imageMap.getOrDefault(p.postId(), List.of())))
                 .toList();
     }
 
-    //스토리 페이지에 앨범 박스
+    // 스토리 페이지에 앨범 박스
     public List<AlbumCardResponse> getRecentAlbums(Long clubId, Long viewerId, int limit) {
         clubAuthorizationService.validateAndGetClubForReadPosts(clubId, viewerId);
 
         List<RecentAlbumRow> rows = postRepository.findRecentAlbumRows(
-                clubId, PageRequest.of(0, limit)
-        );
-        if (rows.isEmpty()) return List.of();
+                clubId, PageRequest.of(0, limit));
+        if (rows.isEmpty())
+            return List.of();
 
         List<Long> scheduleIds = rows.stream()
                 .map(RecentAlbumRow::getScheduleId)
@@ -113,7 +122,8 @@ public class PostService {
 
         for (RecentAlbumRow r : rows) {
             List<PostImages> list = imageMap.getOrDefault(r.getScheduleId(), List.of());
-            if (list.isEmpty()) continue;
+            if (list.isEmpty())
+                continue;
 
             PostImages cover = list.getFirst(); // createdAt desc 기준 1장
 
@@ -124,8 +134,7 @@ public class PostService {
                     r.getScheduleName(),
                     cover.getImageUrl(),
                     list.size(),
-                    r.getLastCreatedAt()
-            ));
+                    r.getLastCreatedAt()));
         }
 
         return result;
@@ -243,7 +252,8 @@ public class PostService {
     private void replaceImages(Posts post, List<String> imagesUrl) {
         postImageRepository.deleteByPost_PostId(post.getPostId());
 
-        if (imagesUrl.isEmpty()) return;
+        if (imagesUrl.isEmpty())
+            return;
 
         List<PostImages> images = imagesUrl.stream()
                 .map(url -> PostImages.of(post, url))
@@ -255,7 +265,8 @@ public class PostService {
     private void replaceTaggedMembers(Long postId, List<Long> memberIds) {
         postMemberTagRepository.deleteByPostId(postId);
 
-        if (memberIds.isEmpty()) return;
+        if (memberIds.isEmpty())
+            return;
 
         List<PostMemberTags> tags = memberIds.stream()
                 .distinct()

--- a/backend/src/main/java/back/service/schedule/ScheduleService.java
+++ b/backend/src/main/java/back/service/schedule/ScheduleService.java
@@ -59,8 +59,8 @@ public class ScheduleService {
     /**
      * 일정을 생성하고 자동으로 참석/불참 투표를 생성합니다.
      *
-     * @param clubId 모임 ID
-     * @param userId 일정 생성자 ID (현재 로그인한 사용자)
+     * @param clubId  모임 ID
+     * @param userId  일정 생성자 ID (현재 로그인한 사용자)
      * @param request 일정 생성 요청 정보
      * @return 생성된 일정 정보
      */
@@ -77,7 +77,7 @@ public class ScheduleService {
         // 날짜 검증: endDate는 eventDate보다 이후여야 함
         // (DTO 레벨에서 @AssertTrue로 검증하지만, 방어적 프로그래밍을 위해 서비스 레벨에서도 검증)
         if (request.endDate().isBefore(request.eventDate()) ||
-            request.endDate().isEqual(request.eventDate())) {
+                request.endDate().isEqual(request.eventDate())) {
             throw new ScheduleException.InvalidDateRange();
         }
 
@@ -89,8 +89,7 @@ public class ScheduleService {
                 request.endDate(),
                 request.location(),
                 request.description(),
-                request.entryFee()
-        );
+                request.entryFee());
         if (request.voteDeadline() != null) {
             schedule.setVoteDeadline(request.voteDeadline());
         }
@@ -106,7 +105,7 @@ public class ScheduleService {
                 request.description(),
                 false, // isAnonymous
                 false, // allowMultiple
-                null   // deadline은 null (ATTENDANCE 타입은 일정 시작 5분 전 자동 종료)
+                null // deadline은 null (ATTENDANCE 타입은 일정 시작 5분 전 자동 종료)
         );
         Votes savedVote = voteRepository.save(vote);
 
@@ -116,24 +115,22 @@ public class ScheduleService {
                 "참석",
                 1,
                 request.eventDate(),
-                request.location()
-        );
+                request.location());
         VoteOptions notAttendOption = new VoteOptions(
                 savedVote.getVoteId(),
                 "불참",
                 2,
                 null,
-                null
-        );
+                null);
         voteOptionRepository.save(attendOption);
         voteOptionRepository.save(notAttendOption);
 
-        //일정 생성 이벤트 발행
+        // 일정 생성 이벤트 발행
         eventPublisher.publishEvent(new ScheduleRegisteredEvent(
                 clubId,
                 savedSchedule.getScheduleId(),
-                savedSchedule.getScheduleName()
-        ));
+                savedSchedule.getScheduleName(),
+                userId));
 
         return toResponse(savedSchedule);
     }
@@ -182,7 +179,8 @@ public class ScheduleService {
         }
 
         // 참가비 변경 여부 확인
-        java.math.BigDecimal currentEntryFee = schedule.getEntryFee() != null ? schedule.getEntryFee() : java.math.BigDecimal.ZERO;
+        java.math.BigDecimal currentEntryFee = schedule.getEntryFee() != null ? schedule.getEntryFee()
+                : java.math.BigDecimal.ZERO;
         java.math.BigDecimal newEntryFee = request.entryFee() != null ? request.entryFee() : java.math.BigDecimal.ZERO;
         boolean isEntryFeeChanged = currentEntryFee.compareTo(newEntryFee) != 0;
 
@@ -199,8 +197,8 @@ public class ScheduleService {
         }
 
         // 날짜 유효성 검증
-        if (request.endDate().isBefore(request.eventDate()) || 
-            request.endDate().isEqual(request.eventDate())) {
+        if (request.endDate().isBefore(request.eventDate()) ||
+                request.endDate().isEqual(request.eventDate())) {
             throw new ScheduleException.InvalidDateRange();
         }
 
@@ -210,8 +208,7 @@ public class ScheduleService {
                 request.endDate(),
                 request.location(),
                 request.description(),
-                request.entryFee()
-        );
+                request.entryFee());
 
         return toResponse(schedule);
     }
@@ -234,7 +231,8 @@ public class ScheduleService {
         }
 
         // 권한 체크: 참가비가 있으면 총무 이상, 없으면 운영진 이상
-        boolean hasEntryFee = schedule.getEntryFee() != null && schedule.getEntryFee().compareTo(java.math.BigDecimal.ZERO) > 0;
+        boolean hasEntryFee = schedule.getEntryFee() != null
+                && schedule.getEntryFee().compareTo(java.math.BigDecimal.ZERO) > 0;
         if (hasEntryFee) {
             clubAuthService.assertAtLeastAccountant(clubId, userId);
         } else {
@@ -274,7 +272,8 @@ public class ScheduleService {
         }
 
         // 권한 체크: 참가비가 있으면 총무 이상 (환불 문제), 없으면 운영진 이상
-        boolean hasEntryFee = schedule.getEntryFee() != null && schedule.getEntryFee().compareTo(java.math.BigDecimal.ZERO) > 0;
+        boolean hasEntryFee = schedule.getEntryFee() != null
+                && schedule.getEntryFee().compareTo(java.math.BigDecimal.ZERO) > 0;
         if (hasEntryFee) {
             clubAuthService.assertAtLeastAccountant(clubId, userId);
         } else {
@@ -310,7 +309,8 @@ public class ScheduleService {
      * @return 수정된 일정 정보
      */
     @Transactional
-    public ScheduleResponse updateSettlement(Long clubId, Long scheduleId, Long userId, ScheduleSettlementRequest request) {
+    public ScheduleResponse updateSettlement(Long clubId, Long scheduleId, Long userId,
+            ScheduleSettlementRequest request) {
         // 권한 체크: 정산은 무조건 총무 이상만 가능 (돈 관련)
         clubAuthService.assertAtLeastAccountant(clubId, userId);
 
@@ -369,8 +369,7 @@ public class ScheduleService {
                         p.getFeeStatus(),
                         p.getIsRefunded(),
                         p.getCreatedAt(),
-                        p.getUpdatedAt()
-                ))
+                        p.getUpdatedAt()))
                 .collect(Collectors.toList());
     }
 
@@ -390,7 +389,6 @@ public class ScheduleService {
                 schedule.getCancelReason(),
                 schedule.getVoteDeadline(),
                 schedule.getCreatedAt(),
-                schedule.getUpdatedAt()
-        );
+                schedule.getUpdatedAt());
     }
 }

--- a/backend/src/main/java/back/service/vote/VoteScheduler.java
+++ b/backend/src/main/java/back/service/vote/VoteScheduler.java
@@ -1,0 +1,73 @@
+package back.service.vote;
+
+import back.domain.vote.Votes;
+import back.event.VoteDeadlineEvent;
+import back.repository.post.PostRepository;
+import back.repository.schedule.ScheduleRepository;
+import back.repository.vote.VoteRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class VoteScheduler {
+
+    private final VoteRepository voteRepository;
+    private final ScheduleRepository scheduleRepository;
+    private final PostRepository postRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    /**
+     * 매 분마다 마감 시간이 1시간 ~ 1시간 1분 남은 투표를 감지하여 알림을 보냅니다.
+     * (테스트 및 즉각적인 반응을 위해 1분 주기로 설정)
+     */
+    @Scheduled(cron = "0 * * * * *") // 매 분 0초 실행
+    @Transactional(readOnly = true)
+    public void checkUpcomingVoteDeadlines() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime oneHourLater = now.plusHours(1);
+        LocalDateTime oneHourOneMinuteLater = now.plusHours(1).plusMinutes(1);
+
+        // 마감 기한이 [1시간 후 ~ 1시간 1분 후] 사이인 투표 조회
+        List<Votes> upcomingVotes = voteRepository.findUpcomingDeadlines(oneHourLater, oneHourOneMinuteLater);
+
+        if (upcomingVotes.isEmpty()) {
+            return;
+        }
+
+        log.info("Found {} votes with upcoming deadline.", upcomingVotes.size());
+
+        for (Votes vote : upcomingVotes) {
+            Long clubId = getClubId(vote);
+            if (clubId != null) {
+                eventPublisher.publishEvent(new VoteDeadlineEvent(
+                        vote.getVoteId(),
+                        vote.getTitle(),
+                        clubId));
+            } else {
+                log.warn("Vote {} has no associated clubId.", vote.getVoteId());
+            }
+        }
+    }
+
+    private Long getClubId(Votes vote) {
+        if ("ATTENDANCE".equals(vote.getVoteType()) && vote.getScheduleId() != null) {
+            return scheduleRepository.findById(vote.getScheduleId())
+                    .map(schedule -> schedule.getClubId())
+                    .orElse(null);
+        } else if ("GENERAL".equals(vote.getVoteType()) && vote.getPostId() != null) {
+            return postRepository.findById(vote.getPostId())
+                    .map(post -> post.getClub().getClubId())
+                    .orElse(null);
+        }
+        return null;
+    }
+}

--- a/backend/src/test/java/back/listener/NotificationEventListenerTest.java
+++ b/backend/src/test/java/back/listener/NotificationEventListenerTest.java
@@ -1,0 +1,166 @@
+package back.listener;
+
+import back.domain.NotificationType;
+import back.domain.Notifications;
+import back.domain.club.ClubMembers;
+import back.dto.NotificationResponse;
+import back.event.ClubJoinEvent;
+import back.event.CommentCreatedEvent;
+import back.event.PostCreatedEvent;
+import back.event.ScheduleRegisteredEvent;
+import back.event.VoteDeadlineEvent;
+import back.repository.club.ClubMemberRepository;
+import back.repository.notifications.NotificationsRepository;
+import back.service.notifications.NotificationService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationEventListenerTest {
+
+    @Mock
+    private ClubMemberRepository clubMemberRepository;
+
+    @Mock
+    private NotificationsRepository notificationsRepository;
+
+    @Mock
+    private NotificationService notificationService;
+
+    @InjectMocks
+    private NotificationEventListener notificationEventListener;
+
+    @Test
+    @DisplayName("일정 등록 시 알림이 발송되어야 한다")
+    void handleScheduleRegisteredEvent() {
+        // given
+        Long clubId = 1L;
+        Long scheduleId = 100L;
+        Long authorId = 10L;
+        Long otherMemberId = 11L;
+
+        ScheduleRegisteredEvent event = new ScheduleRegisteredEvent(clubId, scheduleId, "테스트 일정", authorId);
+
+        ClubMembers author = mock(ClubMembers.class);
+        given(author.getUserId()).willReturn(authorId);
+
+        ClubMembers otherMember = mock(ClubMembers.class);
+        given(otherMember.getUserId()).willReturn(otherMemberId);
+
+        given(clubMemberRepository.findByClubIdAndStatus(clubId, ClubMembers.Status.ACTIVE))
+                .willReturn(List.of(author, otherMember));
+
+        Notifications notification = new Notifications(otherMemberId, "content", scheduleId,
+                NotificationType.SCHEDULE.name());
+        given(notificationsRepository.saveAll(anyList())).willReturn(List.of(notification));
+
+        // when
+        notificationEventListener.handleScheduleRegisteredEvent(event);
+
+        // then
+        // 작성자(authorId)는 제외되고 otherMemberId에게만 전송되어야 함
+        verify(notificationService).send(eq(otherMemberId), any(NotificationResponse.class));
+        verify(notificationService, never()).send(eq(authorId), any(NotificationResponse.class));
+    }
+
+    @Test
+    @DisplayName("댓글 작성 시 게시글 작성자에게 알림이 발송되어야 한다")
+    void handleCommentCreatedEvent() {
+        // given
+        Long postId = 200L;
+        Long commentAuthorId = 20L;
+        Long postAuthorId = 10L;
+
+        CommentCreatedEvent event = new CommentCreatedEvent(postId, "댓글 내용", commentAuthorId, postAuthorId);
+
+        Notifications notification = new Notifications(postAuthorId, "content", postId,
+                NotificationType.COMMENT.name());
+        given(notificationsRepository.saveAll(anyList())).willReturn(List.of(notification));
+
+        // when
+        notificationEventListener.handleCommentCreatedEvent(event);
+
+        // then
+        verify(notificationService).send(eq(postAuthorId), any(NotificationResponse.class));
+    }
+
+    @Test
+    @DisplayName("본인이 본인 글에 댓글을 달면 알림이 발송되지 않아야 한다")
+    void handleCommentCreatedEvent_Self() {
+        // given
+        Long postId = 200L;
+        Long authorId = 10L;
+
+        CommentCreatedEvent event = new CommentCreatedEvent(postId, "댓글 내용", authorId, authorId);
+
+        // when
+        notificationEventListener.handleCommentCreatedEvent(event);
+
+        // then
+        verify(notificationsRepository, never()).saveAll(anyList());
+        verify(notificationService, never()).send(anyLong(), any());
+    }
+
+    @Test
+    @DisplayName("모임 가입 승인 시 가입자에게 환영 알림이 발송되어야 한다")
+    void handleClubJoinEvent() {
+        // given
+        Long clubId = 1L;
+        Long memberId = 50L;
+        Long userId = 100L;
+        String clubName = "테스트 모임";
+
+        ClubJoinEvent event = new ClubJoinEvent(clubId, memberId, userId, clubName);
+
+        Notifications notification = new Notifications(userId, "content", clubId, NotificationType.CLUB_WELCOME.name());
+        given(notificationsRepository.saveAll(anyList())).willReturn(List.of(notification));
+
+        // when
+        notificationEventListener.handleClubJoinEvent(event);
+
+        // then
+        verify(notificationService).send(eq(userId), any(NotificationResponse.class));
+    }
+
+    @Test
+    @DisplayName("투표 마감 임박 시 모든 멤버에게 알림이 발송되어야 한다")
+    void handleVoteDeadlineEvent() {
+        // given
+        Long clubId = 1L;
+        Long voteId = 300L;
+        Long memberId1 = 10L;
+        Long memberId2 = 11L;
+
+        VoteDeadlineEvent event = new VoteDeadlineEvent(voteId, "투표 제목", clubId);
+
+        ClubMembers member1 = mock(ClubMembers.class);
+        given(member1.getUserId()).willReturn(memberId1);
+        ClubMembers member2 = mock(ClubMembers.class);
+        given(member2.getUserId()).willReturn(memberId2);
+
+        given(clubMemberRepository.findByClubIdAndStatus(clubId, ClubMembers.Status.ACTIVE))
+                .willReturn(List.of(member1, member2));
+
+        Notifications noti1 = new Notifications(memberId1, "content", voteId, NotificationType.VOTE_DEADLINE.name());
+        Notifications noti2 = new Notifications(memberId2, "content", voteId, NotificationType.VOTE_DEADLINE.name());
+
+        given(notificationsRepository.saveAll(anyList())).willReturn(List.of(noti1, noti2));
+
+        // when
+        notificationEventListener.handleVoteDeadlineEvent(event);
+
+        // then
+        verify(notificationService).send(eq(memberId1), any(NotificationResponse.class));
+        verify(notificationService).send(eq(memberId2), any(NotificationResponse.class));
+    }
+}

--- a/backend/src/test/java/back/service/club/ClubMemberServiceTest.java
+++ b/backend/src/test/java/back/service/club/ClubMemberServiceTest.java
@@ -7,6 +7,7 @@ import back.dto.club.ClubMemberResponse;
 import back.exception.ClubException;
 import back.repository.club.ClubMemberRepository;
 import back.repository.club.ClubRepository;
+import org.springframework.context.ApplicationEventPublisher;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -26,333 +27,345 @@ import static org.mockito.BDDMockito.*;
 @ExtendWith(MockitoExtension.class)
 class ClubMemberServiceTest {
 
-    @Mock
-    private ClubMemberRepository clubMemberRepository;
+        @Mock
+        private ClubMemberRepository clubMemberRepository;
 
-    @Mock
-    private ClubRepository clubRepository;
+        @Mock
+        private ClubRepository clubRepository;
 
-    @InjectMocks
-    private ClubMemberService clubMemberService;
+        @Mock
+        private ApplicationEventPublisher eventPublisher;
 
-    private Clubs createClub(Long clubId, Long ownerId) {
-        Clubs club = new Clubs("테스트모임", ownerId);
-        ReflectionTestUtils.setField(club, "clubId", clubId);
-        return club;
-    }
+        @InjectMocks
+        private ClubMemberService clubMemberService;
 
-    @Nested
-    @DisplayName("모임 가입")
-    class JoinClub {
-
-        @Test
-        @DisplayName("새로운 회원 가입 성공")
-        void join_club_success_new_member() {
-            // given
-            Long clubId = 1L;
-            Long userId = 10L;
-            Long ownerId = 999L;
-            ClubMemberRequest request = ClubMemberRequest.builder()
-                    .nickname("테스트닉네임")
-                    .build();
-
-            Clubs club = createClub(clubId, ownerId);
-            given(clubRepository.findById(clubId)).willReturn(Optional.of(club));
-            given(clubMemberRepository.countByClubIdAndStatus(clubId, ClubMembers.Status.ACTIVE)).willReturn(10L);
-            given(clubMemberRepository.existsByClubIdAndNickname(clubId, request.getNickname())).willReturn(false);
-
-            ClubMembers newMember = ClubMembers.builder()
-                    .clubId(clubId)
-                    .userId(userId)
-                    .nickname(request.getNickname())
-                    .build();
-            ReflectionTestUtils.setField(newMember, "memberId", 1L);
-
-            given(clubMemberRepository.findByClubIdAndUserId(clubId, userId))
-                    .willReturn(Optional.empty());
-            given(clubMemberRepository.save(any(ClubMembers.class)))
-                    .willReturn(newMember);
-
-            // when
-            ClubMemberResponse response = clubMemberService.joinClub(clubId, userId, request);
-
-            // then
-            assertThat(response).isNotNull();
-            assertThat(response.getUserId()).isEqualTo(10L);
-            assertThat(response.getNickname()).isEqualTo("테스트닉네임");
-            assertThat(response.getStatus()).isEqualTo("PENDING");
-
-            then(clubMemberRepository).should(times(1)).findByClubIdAndUserId(clubId, userId);
-            then(clubMemberRepository).should(times(1)).save(any(ClubMembers.class));
+        private Clubs createClub(Long clubId, Long ownerId) {
+                Clubs club = new Clubs("테스트모임", ownerId);
+                ReflectionTestUtils.setField(club, "clubId", clubId);
+                return club;
         }
 
-        @Test
-        @DisplayName("기존 회원 재가입 성공 (REJECTED 상태)")
-        void join_club_success_reapply_rejected() {
-            // given
-            Long clubId = 1L;
-            Long userId = 10L;
-            Long ownerId = 999L;
-            ClubMemberRequest request = ClubMemberRequest.builder()
-                    .nickname("새닉네임")
-                    .build();
+        @Nested
+        @DisplayName("모임 가입")
+        class JoinClub {
 
-            Clubs club = createClub(clubId, ownerId);
-            given(clubRepository.findById(clubId)).willReturn(Optional.of(club));
-            given(clubMemberRepository.countByClubIdAndStatus(clubId, ClubMembers.Status.ACTIVE)).willReturn(10L);
-            given(clubMemberRepository.existsByClubIdAndNickname(clubId, request.getNickname())).willReturn(false);
+                @Test
+                @DisplayName("새로운 회원 가입 성공")
+                void join_club_success_new_member() {
+                        // given
+                        Long clubId = 1L;
+                        Long userId = 10L;
+                        Long ownerId = 999L;
+                        ClubMemberRequest request = ClubMemberRequest.builder()
+                                        .nickname("테스트닉네임")
+                                        .build();
 
-            ClubMembers existingMember = ClubMembers.builder()
-                    .clubId(clubId)
-                    .userId(userId)
-                    .nickname("기존닉네임")
-                    .build();
-            ReflectionTestUtils.setField(existingMember, "memberId", 1L);
-            ReflectionTestUtils.setField(existingMember, "status", ClubMembers.Status.REJECTED);
+                        Clubs club = createClub(clubId, ownerId);
+                        given(clubRepository.findById(clubId)).willReturn(Optional.of(club));
+                        given(clubMemberRepository.countByClubIdAndStatus(clubId, ClubMembers.Status.ACTIVE))
+                                        .willReturn(10L);
+                        given(clubMemberRepository.existsByClubIdAndNickname(clubId, request.getNickname()))
+                                        .willReturn(false);
 
-            given(clubMemberRepository.findByClubIdAndUserId(clubId, userId))
-                    .willReturn(Optional.of(existingMember));
+                        ClubMembers newMember = ClubMembers.builder()
+                                        .clubId(clubId)
+                                        .userId(userId)
+                                        .nickname(request.getNickname())
+                                        .build();
+                        ReflectionTestUtils.setField(newMember, "memberId", 1L);
 
-            // when
-            ClubMemberResponse response = clubMemberService.joinClub(clubId, userId, request);
+                        given(clubMemberRepository.findByClubIdAndUserId(clubId, userId))
+                                        .willReturn(Optional.empty());
+                        given(clubMemberRepository.save(any(ClubMembers.class)))
+                                        .willReturn(newMember);
 
-            // then
-            assertThat(response).isNotNull();
-            assertThat(existingMember.getStatus()).isEqualTo(ClubMembers.Status.PENDING);
+                        // when
+                        ClubMemberResponse response = clubMemberService.joinClub(clubId, userId, request);
 
-            then(clubMemberRepository).should(times(1)).findByClubIdAndUserId(clubId, userId);
-            then(clubMemberRepository).should(never()).save(any(ClubMembers.class));
+                        // then
+                        assertThat(response).isNotNull();
+                        assertThat(response.getUserId()).isEqualTo(10L);
+                        assertThat(response.getNickname()).isEqualTo("테스트닉네임");
+                        assertThat(response.getStatus()).isEqualTo("PENDING");
+
+                        then(clubMemberRepository).should(times(1)).findByClubIdAndUserId(clubId, userId);
+                        then(clubMemberRepository).should(times(1)).save(any(ClubMembers.class));
+                }
+
+                @Test
+                @DisplayName("기존 회원 재가입 성공 (REJECTED 상태)")
+                void join_club_success_reapply_rejected() {
+                        // given
+                        Long clubId = 1L;
+                        Long userId = 10L;
+                        Long ownerId = 999L;
+                        ClubMemberRequest request = ClubMemberRequest.builder()
+                                        .nickname("새닉네임")
+                                        .build();
+
+                        Clubs club = createClub(clubId, ownerId);
+                        given(clubRepository.findById(clubId)).willReturn(Optional.of(club));
+                        given(clubMemberRepository.countByClubIdAndStatus(clubId, ClubMembers.Status.ACTIVE))
+                                        .willReturn(10L);
+                        given(clubMemberRepository.existsByClubIdAndNickname(clubId, request.getNickname()))
+                                        .willReturn(false);
+
+                        ClubMembers existingMember = ClubMembers.builder()
+                                        .clubId(clubId)
+                                        .userId(userId)
+                                        .nickname("기존닉네임")
+                                        .build();
+                        ReflectionTestUtils.setField(existingMember, "memberId", 1L);
+                        ReflectionTestUtils.setField(existingMember, "status", ClubMembers.Status.REJECTED);
+
+                        given(clubMemberRepository.findByClubIdAndUserId(clubId, userId))
+                                        .willReturn(Optional.of(existingMember));
+
+                        // when
+                        ClubMemberResponse response = clubMemberService.joinClub(clubId, userId, request);
+
+                        // then
+                        assertThat(response).isNotNull();
+                        assertThat(existingMember.getStatus()).isEqualTo(ClubMembers.Status.PENDING);
+
+                        then(clubMemberRepository).should(times(1)).findByClubIdAndUserId(clubId, userId);
+                        then(clubMemberRepository).should(never()).save(any(ClubMembers.class));
+                }
+
+                @Test
+                @DisplayName("기존 회원 재가입 성공 (LEFT 상태)")
+                void join_club_success_reapply_left() {
+                        // given
+                        Long clubId = 1L;
+                        Long userId = 10L;
+                        Long ownerId = 999L;
+                        ClubMemberRequest request = ClubMemberRequest.builder()
+                                        .nickname("새닉네임")
+                                        .build();
+
+                        Clubs club = createClub(clubId, ownerId);
+                        given(clubRepository.findById(clubId)).willReturn(Optional.of(club));
+                        given(clubMemberRepository.countByClubIdAndStatus(clubId, ClubMembers.Status.ACTIVE))
+                                        .willReturn(10L);
+                        given(clubMemberRepository.existsByClubIdAndNickname(clubId, request.getNickname()))
+                                        .willReturn(false);
+
+                        ClubMembers existingMember = ClubMembers.builder()
+                                        .clubId(clubId)
+                                        .userId(userId)
+                                        .nickname("기존닉네임")
+                                        .build();
+                        ReflectionTestUtils.setField(existingMember, "memberId", 1L);
+                        ReflectionTestUtils.setField(existingMember, "status", ClubMembers.Status.LEFT);
+
+                        given(clubMemberRepository.findByClubIdAndUserId(clubId, userId))
+                                        .willReturn(Optional.of(existingMember));
+
+                        // when
+                        ClubMemberResponse response = clubMemberService.joinClub(clubId, userId, request);
+
+                        // then
+                        assertThat(response).isNotNull();
+                        assertThat(existingMember.getStatus()).isEqualTo(ClubMembers.Status.PENDING);
+
+                        then(clubMemberRepository).should(times(1)).findByClubIdAndUserId(clubId, userId);
+                }
         }
 
-        @Test
-        @DisplayName("기존 회원 재가입 성공 (LEFT 상태)")
-        void join_club_success_reapply_left() {
-            // given
-            Long clubId = 1L;
-            Long userId = 10L;
-            Long ownerId = 999L;
-            ClubMemberRequest request = ClubMemberRequest.builder()
-                    .nickname("새닉네임")
-                    .build();
+        @Nested
+        @DisplayName("가입 승인")
+        class ApproveClubMember {
 
-            Clubs club = createClub(clubId, ownerId);
-            given(clubRepository.findById(clubId)).willReturn(Optional.of(club));
-            given(clubMemberRepository.countByClubIdAndStatus(clubId, ClubMembers.Status.ACTIVE)).willReturn(10L);
-            given(clubMemberRepository.existsByClubIdAndNickname(clubId, request.getNickname())).willReturn(false);
+                @Test
+                @DisplayName("가입 승인 성공")
+                void approve_club_member_success() {
+                        // given
+                        Long clubId = 1L;
+                        Long memberId = 1L;
+                        Long userId = 10L;
 
-            ClubMembers existingMember = ClubMembers.builder()
-                    .clubId(clubId)
-                    .userId(userId)
-                    .nickname("기존닉네임")
-                    .build();
-            ReflectionTestUtils.setField(existingMember, "memberId", 1L);
-            ReflectionTestUtils.setField(existingMember, "status", ClubMembers.Status.LEFT);
+                        ClubMembers member = ClubMembers.builder()
+                                        .clubId(clubId)
+                                        .userId(userId)
+                                        .nickname("테스트닉네임")
+                                        .build();
+                        ReflectionTestUtils.setField(member, "memberId", memberId);
+                        ReflectionTestUtils.setField(member, "status", ClubMembers.Status.PENDING);
 
-            given(clubMemberRepository.findByClubIdAndUserId(clubId, userId))
-                    .willReturn(Optional.of(existingMember));
+                        given(clubMemberRepository.findByClubIdAndMemberId(clubId, memberId))
+                                        .willReturn(Optional.of(member));
 
-            // when
-            ClubMemberResponse response = clubMemberService.joinClub(clubId, userId, request);
+                        Clubs club = createClub(clubId, 999L);
+                        given(clubRepository.findById(clubId)).willReturn(Optional.of(club));
 
-            // then
-            assertThat(response).isNotNull();
-            assertThat(existingMember.getStatus()).isEqualTo(ClubMembers.Status.PENDING);
+                        // when
+                        ClubMemberResponse response = clubMemberService.approveClubMember(clubId, memberId);
 
-            then(clubMemberRepository).should(times(1)).findByClubIdAndUserId(clubId, userId);
-        }
-    }
+                        // then
+                        assertThat(response).isNotNull();
+                        assertThat(member.getStatus()).isEqualTo(ClubMembers.Status.ACTIVE);
+                        assertThat(member.getJoinedAt()).isNotNull();
 
-    @Nested
-    @DisplayName("가입 승인")
-    class ApproveClubMember {
+                        then(clubMemberRepository).should(times(1)).findByClubIdAndMemberId(clubId, memberId);
+                }
 
-        @Test
-        @DisplayName("가입 승인 성공")
-        void approve_club_member_success() {
-            // given
-            Long clubId = 1L;
-            Long memberId = 1L;
-            Long userId = 10L;
+                @Test
+                @DisplayName("가입 승인 실패 - 회원 없음")
+                void approve_club_member_fail_not_found() {
+                        // given
+                        Long clubId = 1L;
+                        Long memberId = 10L;
 
-            ClubMembers member = ClubMembers.builder()
-                    .clubId(clubId)
-                    .userId(userId)
-                    .nickname("테스트닉네임")
-                    .build();
-            ReflectionTestUtils.setField(member, "memberId", memberId);
-            ReflectionTestUtils.setField(member, "status", ClubMembers.Status.PENDING);
+                        given(clubMemberRepository.findByClubIdAndMemberId(clubId, memberId))
+                                        .willReturn(Optional.empty());
 
-            given(clubMemberRepository.findByClubIdAndMemberId(clubId, memberId))
-                    .willReturn(Optional.of(member));
+                        // when & then
+                        assertThatThrownBy(() -> clubMemberService.approveClubMember(clubId, memberId))
+                                        .isInstanceOf(ClubException.MemberNotFound.class);
+                }
 
-            // when
-            ClubMemberResponse response = clubMemberService.approveClubMember(clubId, memberId);
+                @Test
+                @DisplayName("가입 승인 실패 - PENDING 상태가 아님")
+                void approve_club_member_fail_not_pending() {
+                        // given
+                        Long clubId = 1L;
+                        Long memberId = 1L;
+                        Long userId = 10L;
 
-            // then
-            assertThat(response).isNotNull();
-            assertThat(member.getStatus()).isEqualTo(ClubMembers.Status.ACTIVE);
-            assertThat(member.getJoinedAt()).isNotNull();
+                        ClubMembers member = ClubMembers.builder()
+                                        .clubId(clubId)
+                                        .userId(userId)
+                                        .nickname("테스트닉네임")
+                                        .build();
+                        ReflectionTestUtils.setField(member, "memberId", memberId);
+                        ReflectionTestUtils.setField(member, "status", ClubMembers.Status.ACTIVE);
 
-            then(clubMemberRepository).should(times(1)).findByClubIdAndMemberId(clubId, memberId);
-        }
+                        given(clubMemberRepository.findByClubIdAndMemberId(clubId, memberId))
+                                        .willReturn(Optional.of(member));
 
-        @Test
-        @DisplayName("가입 승인 실패 - 회원 없음")
-        void approve_club_member_fail_not_found() {
-            // given
-            Long clubId = 1L;
-            Long memberId = 10L;
-
-            given(clubMemberRepository.findByClubIdAndMemberId(clubId, memberId))
-                    .willReturn(Optional.empty());
-
-            // when & then
-            assertThatThrownBy(() -> clubMemberService.approveClubMember(clubId, memberId))
-                    .isInstanceOf(ClubException.MemberNotFound.class);
+                        // when & then
+                        assertThatThrownBy(() -> clubMemberService.approveClubMember(clubId, memberId))
+                                        .isInstanceOf(ClubException.MemberNotPending.class);
+                }
         }
 
-        @Test
-        @DisplayName("가입 승인 실패 - PENDING 상태가 아님")
-        void approve_club_member_fail_not_pending() {
-            // given
-            Long clubId = 1L;
-            Long memberId = 1L;
-            Long userId = 10L;
+        @Nested
+        @DisplayName("가입 거절")
+        class RejectClubMember {
 
-            ClubMembers member = ClubMembers.builder()
-                    .clubId(clubId)
-                    .userId(userId)
-                    .nickname("테스트닉네임")
-                    .build();
-            ReflectionTestUtils.setField(member, "memberId", memberId);
-            ReflectionTestUtils.setField(member, "status", ClubMembers.Status.ACTIVE);
+                @Test
+                @DisplayName("가입 거절 성공")
+                void reject_club_member_success() {
+                        // given
+                        Long clubId = 1L;
+                        Long memberId = 1L;
 
-            given(clubMemberRepository.findByClubIdAndMemberId(clubId, memberId))
-                    .willReturn(Optional.of(member));
+                        ClubMembers member = ClubMembers.builder()
+                                        .clubId(clubId)
+                                        .userId(10L)
+                                        .nickname("테스트닉네임")
+                                        .build();
+                        ReflectionTestUtils.setField(member, "memberId", memberId);
+                        ReflectionTestUtils.setField(member, "status", ClubMembers.Status.PENDING);
 
-            // when & then
-            assertThatThrownBy(() -> clubMemberService.approveClubMember(clubId, memberId))
-                    .isInstanceOf(ClubException.MemberNotPending.class);
-        }
-    }
+                        given(clubMemberRepository.findByClubIdAndMemberId(clubId, memberId))
+                                        .willReturn(Optional.of(member));
 
-    @Nested
-    @DisplayName("가입 거절")
-    class RejectClubMember {
+                        // when
+                        clubMemberService.rejectClubMember(clubId, memberId);
 
-        @Test
-        @DisplayName("가입 거절 성공")
-        void reject_club_member_success() {
-            // given
-            Long clubId = 1L;
-            Long memberId = 1L;
+                        // then
+                        assertThat(member.getStatus()).isEqualTo(ClubMembers.Status.REJECTED);
 
-            ClubMembers member = ClubMembers.builder()
-                    .clubId(clubId)
-                    .userId(10L)
-                    .nickname("테스트닉네임")
-                    .build();
-            ReflectionTestUtils.setField(member, "memberId", memberId);
-            ReflectionTestUtils.setField(member, "status", ClubMembers.Status.PENDING);
+                        then(clubMemberRepository).should(times(1)).findByClubIdAndMemberId(clubId, memberId);
+                }
 
-            given(clubMemberRepository.findByClubIdAndMemberId(clubId, memberId))
-                    .willReturn(Optional.of(member));
+                @Test
+                @DisplayName("가입 거절 실패 - 회원 없음")
+                void reject_club_member_fail_not_found() {
+                        // given
+                        Long clubId = 1L;
+                        Long memberId = 999L;
 
-            // when
-            clubMemberService.rejectClubMember(clubId, memberId);
+                        given(clubMemberRepository.findByClubIdAndMemberId(clubId, memberId))
+                                        .willReturn(Optional.empty());
 
-            // then
-            assertThat(member.getStatus()).isEqualTo(ClubMembers.Status.REJECTED);
+                        // when & then
+                        assertThatThrownBy(() -> clubMemberService.rejectClubMember(clubId, memberId))
+                                        .isInstanceOf(ClubException.MemberNotFound.class);
+                }
 
-            then(clubMemberRepository).should(times(1)).findByClubIdAndMemberId(clubId, memberId);
-        }
+                @Test
+                @DisplayName("가입 거절 실패 - 다른 모임의 회원")
+                void reject_club_member_fail_club_mismatch() {
+                        // given
+                        Long clubId = 1L;
+                        Long otherClubId = 999L;
+                        Long memberId = 1L;
 
-        @Test
-        @DisplayName("가입 거절 실패 - 회원 없음")
-        void reject_club_member_fail_not_found() {
-            // given
-            Long clubId = 1L;
-            Long memberId = 999L;
+                        ClubMembers member = ClubMembers.builder()
+                                        .clubId(otherClubId)
+                                        .userId(10L)
+                                        .nickname("테스트닉네임")
+                                        .build();
+                        ReflectionTestUtils.setField(member, "memberId", memberId);
 
-            given(clubMemberRepository.findByClubIdAndMemberId(clubId, memberId))
-                    .willReturn(Optional.empty());
+                        given(clubMemberRepository.findByClubIdAndMemberId(clubId, memberId))
+                                        .willReturn(Optional.empty());
 
-            // when & then
-            assertThatThrownBy(() -> clubMemberService.rejectClubMember(clubId, memberId))
-                    .isInstanceOf(ClubException.MemberNotFound.class);
-        }
-
-        @Test
-        @DisplayName("가입 거절 실패 - 다른 모임의 회원")
-        void reject_club_member_fail_club_mismatch() {
-            // given
-            Long clubId = 1L;
-            Long otherClubId = 999L;
-            Long memberId = 1L;
-
-            ClubMembers member = ClubMembers.builder()
-                    .clubId(otherClubId)
-                    .userId(10L)
-                    .nickname("테스트닉네임")
-                    .build();
-            ReflectionTestUtils.setField(member, "memberId", memberId);
-
-            given(clubMemberRepository.findByClubIdAndMemberId(clubId, memberId))
-                    .willReturn(Optional.empty());
-
-            // when & then
-            assertThatThrownBy(() -> clubMemberService.rejectClubMember(clubId, memberId))
-                    .isInstanceOf(ClubException.MemberNotFound.class);
-        }
-    }
-
-    @Nested
-    @DisplayName("회원 강퇴")
-    class KickMember {
-
-        @Test
-        @DisplayName("회원 강퇴 성공")
-        void kick_member_success() {
-            // given
-            Long clubId = 1L;
-            Long memberId = 1L;
-            Long userId = 10L;
-
-            ClubMembers member = ClubMembers.builder()
-                    .clubId(clubId)
-                    .userId(userId)
-                    .nickname("테스트닉네임")
-                    .build();
-            ReflectionTestUtils.setField(member, "memberId", memberId);
-            ReflectionTestUtils.setField(member, "status", ClubMembers.Status.ACTIVE);
-            ReflectionTestUtils.setField(member, "role", ClubMembers.Role.MEMBER);
-
-            given(clubMemberRepository.findByClubIdAndMemberId(clubId, memberId))
-                    .willReturn(Optional.of(member));
-
-            // when
-            clubMemberService.kickMember(clubId, memberId);
-
-            // then
-            assertThat(member.getStatus()).isEqualTo(ClubMembers.Status.KICKED);
-            assertThat(member.getRole()).isEqualTo(ClubMembers.Role.NONE);
-
-            then(clubMemberRepository).should(times(1)).findByClubIdAndMemberId(clubId, memberId);
+                        // when & then
+                        assertThatThrownBy(() -> clubMemberService.rejectClubMember(clubId, memberId))
+                                        .isInstanceOf(ClubException.MemberNotFound.class);
+                }
         }
 
-        @Test
-        @DisplayName("회원 강퇴 실패 - 회원 없음")
-        void kick_member_fail_not_found() {
-            // given
-            Long clubId = 1L;
-            Long memberId = 10L;
+        @Nested
+        @DisplayName("회원 강퇴")
+        class KickMember {
 
-            given(clubMemberRepository.findByClubIdAndMemberId(clubId, memberId))
-                    .willReturn(Optional.empty());
+                @Test
+                @DisplayName("회원 강퇴 성공")
+                void kick_member_success() {
+                        // given
+                        Long clubId = 1L;
+                        Long memberId = 1L;
+                        Long userId = 10L;
 
-            // when & then
-            assertThatThrownBy(() -> clubMemberService.kickMember(clubId, memberId))
-                    .isInstanceOf(ClubException.MemberNotFound.class);
+                        ClubMembers member = ClubMembers.builder()
+                                        .clubId(clubId)
+                                        .userId(userId)
+                                        .nickname("테스트닉네임")
+                                        .build();
+                        ReflectionTestUtils.setField(member, "memberId", memberId);
+                        ReflectionTestUtils.setField(member, "status", ClubMembers.Status.ACTIVE);
+                        ReflectionTestUtils.setField(member, "role", ClubMembers.Role.MEMBER);
+
+                        given(clubMemberRepository.findByClubIdAndMemberId(clubId, memberId))
+                                        .willReturn(Optional.of(member));
+
+                        // when
+                        clubMemberService.kickMember(clubId, memberId);
+
+                        // then
+                        assertThat(member.getStatus()).isEqualTo(ClubMembers.Status.KICKED);
+                        assertThat(member.getRole()).isEqualTo(ClubMembers.Role.NONE);
+
+                        then(clubMemberRepository).should(times(1)).findByClubIdAndMemberId(clubId, memberId);
+                }
+
+                @Test
+                @DisplayName("회원 강퇴 실패 - 회원 없음")
+                void kick_member_fail_not_found() {
+                        // given
+                        Long clubId = 1L;
+                        Long memberId = 10L;
+
+                        given(clubMemberRepository.findByClubIdAndMemberId(clubId, memberId))
+                                        .willReturn(Optional.empty());
+
+                        // when & then
+                        assertThatThrownBy(() -> clubMemberService.kickMember(clubId, memberId))
+                                        .isInstanceOf(ClubException.MemberNotFound.class);
+                }
         }
-    }
 }

--- a/backend/src/test/java/back/service/post/PostServiceTests.java
+++ b/backend/src/test/java/back/service/post/PostServiceTests.java
@@ -26,6 +26,7 @@ import back.repository.post.PostMemberTagRepository;
 import back.repository.post.PostRepository;
 import back.repository.UserRepository;
 import back.service.club.ClubAuthService;
+import org.springframework.context.ApplicationEventPublisher;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -51,1131 +52,1211 @@ import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
 public class PostServiceTests {
-    @Mock private ClubAuthService clubAuthorizationService;
-
-    @Mock private ClubRepository clubsRepository;
-    @Mock private UserRepository userRepository;
-    @Mock private ScheduleRepository scheduleRepository;
-
-    @Mock private PostRepository postRepository;
-    @Mock private PostImageRepository postImageRepository;
-    @Mock private PostMemberTagRepository postMemberTagRepository;
-
-    @Mock private PostCommentRepository postCommentRepository;
-
-    @InjectMocks
-    private PostService postService;
-
-    @InjectMocks
-    private PostCommentService postCommentService;
-
-    private static <T> T newEntity(Class<T> type) {
-        try {
-            var ctor = type.getDeclaredConstructor();
-            ctor.setAccessible(true);
-            return ctor.newInstance();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private Clubs club(Long id) {
-        Clubs c = newEntity(Clubs.class);
-        ReflectionTestUtils.setField(c, "clubId", id);
-        return c;
-    }
-
-    private Users user(Long id) {
-        Users u = newEntity(Users.class);
-        ReflectionTestUtils.setField(u, "userId", id);
-        return u;
-    }
-
-    private Schedules schedule(Long id) {
-        Schedules s = newEntity(Schedules.class);
-        ReflectionTestUtils.setField(s, "scheduleId", id);
-        return s;
-    }
-
-    @Nested
-    @DisplayName("모임 게시글 전체 조회")
-    class ListPosts { /* 목록 */
-
-        @Test
-        @DisplayName("[GUEST] 공개 모임 게시글 조회 성공")
-        void list_club_public_posts_public() {
-            // given
-            Long clubId = 1L;
-            Long viewerId = null; // 게스트면 null 쓰는 정책이면
-            Pageable pageable = PageRequest.of(0, 10);
-
-            // 권한 통과 스텁
-            willDoNothing().given(clubAuthorizationService)
-                    .validateAndGetClubForReadPosts(clubId, viewerId);
-
-            // repository가 반환하는 projection mock
-            PostCardBase p1 = mock(PostCardBase.class);
-            given(p1.postId()).willReturn(1L);
-            PostCardBase p2 = mock(PostCardBase.class);
-            given(p2.postId()).willReturn(2L);
-
-            given(postRepository.findPostCards(eq(clubId), eq(pageable)))
-                    .willReturn(new PageImpl<>(List.of(p1, p2), pageable, 2));
-
-            // 이미지 조회 스텁
-            PostImages img1 = mock(PostImages.class);
-            given(img1.getPostId()).willReturn(1L);
-            given(img1.getImageUrl()).willReturn("https://example.com/1.png");
-
-            given(postImageRepository.findByPostIdIn(List.of(1L, 2L)))
-                    .willReturn(List.of(img1));
-
-            // when
-            List<PostCardResponse> result = postService.getRecentPosts(clubId, viewerId, pageable);
-
-            // then
-            assertThat(result).hasSize(2);
-            then(clubAuthorizationService).should().validateAndGetClubForReadPosts(clubId, viewerId);
-            then(postRepository).should().findPostCards(clubId, pageable);
-            then(postImageRepository).should().findByPostIdIn(List.of(1L, 2L));
-        }
-
-        @Test
-        @DisplayName("[GUEST] 비공개 모임 게시글 조회 실패")
-        void list_club_public_posts_private() {
-            // given
-            Long clubId = 1L;
-            Long viewerId = null; // 게스트
-            Pageable pageable = PageRequest.of(0, 10);
-
-            willThrow(new ClubException.AuthLoginRequired()) // 프로젝트 예외로 교체
-                    .given(clubAuthorizationService)
-                    .validateAndGetClubForReadPosts(clubId, viewerId);
-
-            // when & then
-            assertThatThrownBy(() -> postService.getRecentPosts(clubId, viewerId, pageable))
-                    .isInstanceOf(ClubException.class);
-
-            then(postRepository).shouldHaveNoInteractions();
-            then(postImageRepository).shouldHaveNoInteractions();
-        }
-
-        @Test
-        @DisplayName("[MEMBER] 비공개 모임 게시글 조회 성공")
-        void list_club_private() {
-            // given
-            Long clubId = 1L;
-            Long viewerId = 10L; // 멤버
-            Pageable pageable = PageRequest.of(0, 10);
-
-            willDoNothing().given(clubAuthorizationService)
-                    .validateAndGetClubForReadPosts(clubId, viewerId);
-
-            PostCardBase p1 = mock(PostCardBase.class);
-            given(p1.postId()).willReturn(1L);
-
-            given(postRepository.findPostCards(eq(clubId), eq(pageable)))
-                    .willReturn(new PageImpl<>(List.of(p1), pageable, 1));
-
-            given(postImageRepository.findByPostIdIn(List.of(1L)))
-                    .willReturn(List.of()); // 이미지 없는 케이스
-
-            // when
-            List<PostCardResponse> result = postService.getRecentPosts(clubId, viewerId, pageable);
-
-            // then
-            assertThat(result).hasSize(1);
-
-            then(clubAuthorizationService).should().validateAndGetClubForReadPosts(clubId, viewerId);
-            then(postRepository).should().findPostCards(clubId, pageable);
-            then(postImageRepository).should().findByPostIdIn(List.of(1L));
-        }
-    }
-
-    @Nested
-    class GetPostDetail { /* 상세 조회 */
-
-        @Test
-        @DisplayName("[GUEST] 공개 모임 게시글 상세 조회 성공")
-        void get_post_public() {
-            // given
-            Long clubId = 1L;
-            Long postId = 1L;
-            Long viewerId = null;
-
-            willDoNothing().given(clubAuthorizationService)
-                    .validateAndGetClubForReadPosts(clubId, viewerId);
-
-            Clubs club = newEntity(Clubs.class);
-            ReflectionTestUtils.setField(club, "clubId", clubId);
-
-            Users writer = newEntity(Users.class);
-            ReflectionTestUtils.setField(writer, "userId", 10L);
-
-            Schedules schedule = newEntity(Schedules.class);
-            ReflectionTestUtils.setField(schedule, "scheduleId", 100L);
-
-            Posts post = Posts.story(club, writer, schedule, "hello content");
-            ReflectionTestUtils.setField(post, "postId", postId);
-
-            given(postRepository.findByPostIdAndClub_ClubId(postId, clubId))
-                    .willReturn(Optional.of(post));
-
-            // when
-            PostDetailResponse res = postService.getPost(clubId, postId, viewerId);
-
-            // then
-            assertThat(res).isNotNull();
-            assertThat(res.postId()).isEqualTo(postId);
-            assertThat(res.clubId()).isEqualTo(clubId);
-            assertThat(res.writerId()).isEqualTo(10L);
-            assertThat(res.scheduleId()).isEqualTo(100L);
-
-            then(clubAuthorizationService).should(times(1))
-                    .validateAndGetClubForReadPosts(clubId, viewerId);
-            then(postRepository).should(times(1))
-                    .findByPostIdAndClub_ClubId(postId, clubId);
-        }
-
-        @Test
-        @DisplayName("[MEMBER] 게시글 상세 조회 실패 - 없는 게시글")
-        void get_no_post_member() {
-            // given
-            Long clubId = 1L;
-            Long postId = 999L;
-            Long viewerId = 100L;
-
-            willDoNothing().given(clubAuthorizationService)
-                    .validateAndGetClubForReadPosts(clubId, viewerId);
-
-            given(postRepository.findByPostIdAndClub_ClubId(postId, clubId))
-                    .willReturn(Optional.empty());
-
-            // when & then
-            assertThatThrownBy(() -> postService.getPost(clubId, postId, viewerId))
-                    .isInstanceOf(PostsException.PostNotFound.class);
-        }
-
-        @Test
-        @DisplayName("[GUEST] 공개 모임 게시글 상세 조회 실패 - 비공개 게시글")
-        void get_post_private_guest() {
-            // given
-            Long clubId = 1L;
-            Long postId = 1L;
-            Long viewerId = null; // 게스트 정책이면 null
-
-            willThrow(new ClubException.AuthLoginRequired()) // 프로젝트 예외로 교체
-                    .given(clubAuthorizationService)
-                    .validateAndGetClubForReadPosts(clubId, viewerId);
-
-            // when & then
-            assertThatThrownBy(() -> postService.getPost(clubId, postId, viewerId))
-                    .isInstanceOf(ClubException.class);
-
-            then(postRepository).shouldHaveNoInteractions();
-        }
-
-        @Test
-        @DisplayName("[MEMBER] 비공개 모임 게시글 상세 조회 성공")
-        void get_post_private_member() {
-            // given
-            Long clubId = 1L;
-            Long postId = 10L;
-            Long viewerId = 100L; // 멤버
-
-            willDoNothing().given(clubAuthorizationService)
-                    .validateAndGetClubForReadPosts(clubId, viewerId);
-
-            Clubs club = newEntity(Clubs.class);
-            ReflectionTestUtils.setField(club, "clubId", clubId);
-
-            Users writer = newEntity(Users.class);
-            ReflectionTestUtils.setField(writer, "userId", 200L);
-
-            Posts post = Posts.story(club, writer, null, "content");
-            ReflectionTestUtils.setField(post, "postId", postId);
-
-            given(postRepository.findByPostIdAndClub_ClubId(postId, clubId))
-                    .willReturn(Optional.of(post));
-
-            // when
-            PostDetailResponse res = postService.getPost(clubId, postId, viewerId);
-
-            // then
-            assertThat(res).isNotNull();
-            assertThat(res.postId()).isEqualTo(postId);
-
-            then(clubAuthorizationService).should(times(1))
-                    .validateAndGetClubForReadPosts(clubId, viewerId);
-            then(postRepository).should(times(1))
-                    .findByPostIdAndClub_ClubId(postId, clubId);
-        }
-
-        @Nested
-        @DisplayName("게시글 내 댓글 전체 조회")
-        class GetComments {
-
-            @Mock private ClubAuthService clubAuthorizationService;
-            @Mock private PostCommentRepository postCommentRepository;
-
-            @InjectMocks
-            private PostCommentService postCommentService;
-
-            @Test
-            @DisplayName("[GUEST] 공개 모임 댓글 조회 성공 - 페이징 메타 포함")
-            void get_comments_public_guest_success() {
-                // given
-                Long clubId = 1L;
-                Long postId = 10L;
-                Long viewerId = null;
-
-                Pageable pageable = PageRequest.of(0, 2, Sort.by(Sort.Direction.ASC, "createdAt"));
-
-                willDoNothing().given(clubAuthorizationService)
-                        .validateAndGetClubForReadPosts(clubId, viewerId);
-
-                Users w1 = newEntity(Users.class);
-                ReflectionTestUtils.setField(w1, "userId", 100L);
-
-                Comments c1 = newEntity(Comments.class);
-                ReflectionTestUtils.setField(c1, "commentId", 1L);
-                ReflectionTestUtils.setField(c1, "writer", w1);
-                ReflectionTestUtils.setField(c1, "content", "a");
-                ReflectionTestUtils.setField(c1, "createdAt", LocalDateTime.now());
-
-                Users w2 = newEntity(Users.class);
-                ReflectionTestUtils.setField(w2, "userId", 200L);
-
-                Comments c2 = newEntity(Comments.class);
-                ReflectionTestUtils.setField(c2, "commentId", 2L);
-                ReflectionTestUtils.setField(c2, "writer", w2);
-                ReflectionTestUtils.setField(c2, "content", "b");
-                ReflectionTestUtils.setField(c2, "createdAt", LocalDateTime.now());
-
-                // total=5면 hasNext=true (page=0, size=2)
-                Page<Comments> page = new PageImpl<>(List.of(c1, c2), pageable, 5);
-
-                given(postCommentRepository.findAllByPost_PostIdAndPost_Club_ClubIdAndDeletedAtIsNull(
-                        postId, clubId, pageable
-                )).willReturn(page);
-
-                // when
-                PostCommentsResponse res = postCommentService.getPostComments(viewerId, clubId, postId, pageable);
-
-                // then
-                assertThat(res.comments()).hasSize(2);
-                assertThat(res.page()).isEqualTo(0);
-                assertThat(res.size()).isEqualTo(2);
-                assertThat(res.totalElements()).isEqualTo(5);
-                assertThat(res.totalPages()).isEqualTo(3);
-                assertThat(res.hasNext()).isTrue();
-
-                assertThat(res.comments().getFirst().commentId()).isEqualTo(1L);
-                assertThat(res.comments().getFirst().writerId()).isEqualTo(100L);
-                assertThat(res.comments().getFirst().content()).isEqualTo("a");
-
-                then(clubAuthorizationService).should(times(1))
-                        .validateAndGetClubForReadPosts(clubId, viewerId);
-                then(postCommentRepository).should(times(1))
-                        .findAllByPost_PostIdAndPost_Club_ClubIdAndDeletedAtIsNull(postId, clubId, pageable);
-            }
-
-            @Test
-            @DisplayName("[MEMBER] 댓글 조회 성공 - 결과 없음")
-            void get_comments_empty() {
-                // given
-                Long clubId = 1L;
-                Long postId = 10L;
-                Long viewerId = 100L;
-
-                Pageable pageable = PageRequest.of(0, 20);
-
-                willDoNothing().given(clubAuthorizationService)
-                        .validateAndGetClubForReadPosts(clubId, viewerId);
-
-                Page<Comments> empty = Page.empty(pageable);
-
-                given(postCommentRepository.findAllByPost_PostIdAndPost_Club_ClubIdAndDeletedAtIsNull(
-                        postId, clubId, pageable
-                )).willReturn(empty);
-
-                // when
-                PostCommentsResponse res = postCommentService.getPostComments(viewerId, clubId, postId, pageable);
-
-                // then
-                assertThat(res.comments()).isEmpty();
-                assertThat(res.hasNext()).isFalse();
-                assertThat(res.totalElements()).isEqualTo(0);
-            }
-
-            @Test
-            @DisplayName("[GUEST] 비공개 모임 댓글 조회 실패 - 권한 없음")
-            void get_comments_private_guest_fail() {
-                // given
-                Long clubId = 1L;
-                Long postId = 10L;
-                Long viewerId = null;
-
-                Pageable pageable = PageRequest.of(0, 20);
-
-                willThrow(new ClubException.AuthLoginRequired()) // 프로젝트 예외로 교체
-                        .given(clubAuthorizationService)
-                        .validateAndGetClubForReadPosts(clubId, viewerId);
-
-                // when & then
-                assertThatThrownBy(() -> postCommentService.getPostComments(viewerId, clubId, postId, pageable))
-                        .isInstanceOf(ClubException.class);
-
-                then(postCommentRepository).shouldHaveNoInteractions();
-            }
-
-            private static <T> T newEntity(Class<T> type) {
+        @Mock
+        private ClubAuthService clubAuthorizationService;
+
+        @Mock
+        private ClubRepository clubsRepository;
+        @Mock
+        private UserRepository userRepository;
+        @Mock
+        private ScheduleRepository scheduleRepository;
+
+        @Mock
+        private PostRepository postRepository;
+        @Mock
+        private PostImageRepository postImageRepository;
+        @Mock
+        private PostMemberTagRepository postMemberTagRepository;
+        @Mock
+        private org.springframework.context.ApplicationEventPublisher eventPublisher;
+
+        @Mock
+        private PostCommentRepository postCommentRepository;
+
+        @InjectMocks
+        private PostService postService;
+
+        @InjectMocks
+        private PostCommentService postCommentService;
+
+        private static <T> T newEntity(Class<T> type) {
                 try {
-                    var ctor = type.getDeclaredConstructor();
-                    ctor.setAccessible(true);
-                    return ctor.newInstance();
+                        var ctor = type.getDeclaredConstructor();
+                        ctor.setAccessible(true);
+                        return ctor.newInstance();
                 } catch (Exception e) {
-                    throw new RuntimeException(e);
+                        throw new RuntimeException(e);
                 }
-            }
         }
-
-        @Nested
-        @DisplayName("게시글 내 좋아요 수 조회")
-        class getLikes {
-        }
-    }
-
-    @Nested
-    class CreatePost { /* 게시글 생성 */
-
-        @Test
-        @DisplayName("[MEMBER] 모임 게시글 생성 성공 - 이미지/태그 없음")
-        void create_post_member_success_without_images_tags() {
-            Long clubId = 1L;
-            Long writerId = 1L;
-
-            StoryCreateRequest request = new StoryCreateRequest(
-                    null,
-                    "모임 게시글 생성",
-                    null,
-                    "  남한산성  ",
-                    null
-            );
-
-            Clubs clubRef = club(clubId);
-            Users writerRef = user(writerId);
-
-            given(clubsRepository.getReferenceById(clubId)).willReturn(clubRef);
-            given(userRepository.getReferenceById(writerId)).willReturn(writerRef);
-
-            Posts savedPost = Posts.story(clubRef, writerRef, null, request.content());
-            ReflectionTestUtils.setField(savedPost, "postId", 10L);
-
-            given(postRepository.save(any(Posts.class))).willReturn(savedPost);
-
-            PostIdResponse res = postService.createStory(clubId, writerId, request);
-
-            assertThat(res.postId()).isEqualTo(10L);
-
-            then(postRepository).should(times(1)).save(any(Posts.class));
-            then(postImageRepository).shouldHaveNoInteractions();
-            then(postMemberTagRepository).shouldHaveNoInteractions();
-        }
-
-        @Test
-        @DisplayName("[MEMBER] 모임 게시글 생성 성공 - 이미지/태그 저장 포함")
-        void create_post_member_success_with_images_tags() {
-            Long clubId = 1L;
-            Long writerId = 1L;
-
-            StoryCreateRequest request = new StoryCreateRequest(
-                    1L,
-                    "모임 게시글 생성",
-                    List.of("https://example.com/1.png", "https://example.com/2.png"),
-                    "강남역",
-                    List.of(2L, 3L)
-            );
-
-            Clubs clubRef = club(clubId);
-            Users writerRef = user(writerId);
-            Schedules scheduleRef = schedule(1L);
-
-            given(clubsRepository.getReferenceById(clubId)).willReturn(clubRef);
-            given(userRepository.getReferenceById(writerId)).willReturn(writerRef);
-            given(scheduleRepository.getReferenceById(1L)).willReturn(scheduleRef);
-
-            Posts savedPost = Posts.story(clubRef, writerRef, scheduleRef, request.content());
-            ReflectionTestUtils.setField(savedPost, "postId", 1L);
-
-            given(postRepository.save(any(Posts.class))).willReturn(savedPost);
-
-            PostIdResponse res = postService.createStory(clubId, writerId, request);
-
-            assertThat(res.postId()).isEqualTo(1L);
-
-            then(postImageRepository).should(times(1)).deleteByPost_PostId(1L);
-            then(postImageRepository).should(times(1)).saveAll(anyList());
-
-            then(postMemberTagRepository).should(times(1)).deleteByPostId(1L);
-            then(postMemberTagRepository).should(times(1)).saveAll(anyList());
-        }
-
-        @Test
-        @DisplayName("[GUEST] 모임 게시글 생성 실패 - 게시글 생성 권한 없음")
-        void create_post_guest() {
-            // given
-            Long clubId = 1L;
-            Long writerId = 999L; // 게스트/비회원 가정
-
-            StoryCreateRequest request = new StoryCreateRequest(
-                    null,
-                    "content",
-                    null,
-                    null,
-                    null
-            );
-
-            willThrow(new ClubException.AuthLoginRequired()) // 프로젝트 예외로 교체
-                    .given(clubAuthorizationService)
-                    .assertActiveMember(clubId, writerId);
-
-            // when & then
-            assertThatThrownBy(() -> postService.createStory(clubId, writerId, request))
-                    .isInstanceOf(ClubException.class);
-
-            then(postRepository).shouldHaveNoInteractions();
-            then(postImageRepository).shouldHaveNoInteractions();
-            then(postMemberTagRepository).shouldHaveNoInteractions();
-        }
-
-        @Nested
-        class CreateComment {
-
-            @Mock private ClubAuthService clubAuthorizationService;
-            @Mock private PostRepository postRepository;
-            @Mock private PostCommentRepository postCommentRepository;
-            @Mock private UserRepository userRepository;
-
-            @InjectMocks
-            private PostCommentService postCommentService;
-
-            @Test
-            @DisplayName("[MEMBER] 댓글 생성 성공 - id 반환")
-            void create_comment_member_success() {
-                // given
-                Long clubId = 1L;
-                Long postId = 10L;
-                Long writerId = 100L;
-
-                PostCommentRequest req = new PostCommentRequest("hi");
-
-                willDoNothing().given(clubAuthorizationService)
-                        .assertActiveMember(clubId, writerId);
-
-                // posts 존재 확인을 한다면(서비스 구현에 따라)
-                Posts postRef = newEntity(Posts.class);
-                ReflectionTestUtils.setField(postRef, "postId", postId);
-                given(postRepository.getReferenceById(postId)).willReturn(postRef);
-
-                Comments saved = newEntity(Comments.class);
-                ReflectionTestUtils.setField(saved, "commentId", 55L);
-                given(postCommentRepository.save(any(Comments.class))).willReturn(saved);
-
-                // when
-                PostCommentsIdResponse res = postCommentService.createComment(writerId, clubId, postId, req);
-
-                // then
-                assertThat(res.commentId()).isEqualTo(55L);
-                verify(clubAuthorizationService).assertActiveMember(anyLong(), eq(writerId));
-                verifyNoMoreInteractions(clubAuthorizationService);            }
-
-            @Test
-            @DisplayName("[GUEST] 댓글 생성 실패 - 권한 없음")
-            void create_comment_guest_fail() {
-                // given
-                Long clubId = 1L;
-                Long postId = 10L;
-                Long writerId = 999L;
-
-                PostCommentRequest req = new PostCommentRequest("hi");
-
-                willThrow(new ClubException.AuthLoginRequired()) // 프로젝트 예외로 교체
-                        .given(clubAuthorizationService)
-                        .assertActiveMember(clubId, writerId);
-
-                // when & then
-                assertThatThrownBy(() -> postCommentService.createComment(writerId, clubId, postId, req))
-                        .isInstanceOf(ClubException.class);
-
-                then(postCommentRepository).shouldHaveNoInteractions();
-            }
-        }
-
-        @Nested
-        class CreateLike {
-        }
-    }
-
-    @Nested
-    class UpdatePost { /* 수정 */
-
-        @Test
-        @DisplayName("[MEMBER] 모임 게시글 수정 성공")
-        void update_post_member() {
-            // given
-            Long clubId = 1L;
-            Long postId = 10L;
-            Long writerId = 100L; // actor == writer
-
-            Clubs club = club(clubId);
-            Users writer = user(writerId);
-
-            Posts post = Posts.story(club, writer, null, "old content");
-            ReflectionTestUtils.setField(post, "postId", postId);
-
-            given(postRepository.findByPostIdAndClub_ClubId(postId, clubId))
-                    .willReturn(Optional.of(post));
-
-            StoryUpdateRequest request = new StoryUpdateRequest(
-                    "new content",
-                    null,
-                    null,
-                    null
-            );
-
-            // when
-            PostIdResponse res = postService.updatePost(clubId, postId, writerId, request);
-
-            // then
-            assertThat(res.postId()).isEqualTo(postId);
-            assertThat(post.getContent()).isEqualTo("new content");
-            assertThat(post.getPlace()).isEqualTo(null);
-
-            then(clubAuthorizationService).shouldHaveNoInteractions(); // 작성자면 매니저 체크 안 탐
-            then(postImageRepository).shouldHaveNoInteractions();
-            then(postMemberTagRepository).shouldHaveNoInteractions();
-        }
-
-        @Test
-        @DisplayName("[ADMIN] 모임 게시글 수정 성공")
-        void update_post_admin_ban() {
-            // given
-            Long clubId = 1L;
-            Long postId = 10L;
-            Long writerId = 100L;
-            Long adminId = 999L; // actor != writer
-
-            Clubs club = club(clubId);
-            Users writer = user(writerId);
-
-            Posts post = Posts.story(club, writer, null, "old content");
-            ReflectionTestUtils.setField(post, "postId", postId);
-
-            given(postRepository.findByPostIdAndClub_ClubId(postId, clubId))
-                    .willReturn(Optional.of(post));
-
-            // 관리자 이상 허용
-            willDoNothing().given(clubAuthorizationService)
-                    .assertAtLeastManager(clubId, adminId);
-
-            StoryUpdateRequest request = new StoryUpdateRequest(
-                    "admin updated",
-                    List.of(),            // 빈 리스트면 전체 삭제(= delete 호출) 기대
-                    null,
-                    List.of(2L, 2L, 3L)   // 중복 포함 -> distinct 후 저장
-            );
-
-            // when
-            PostIdResponse res = postService.updatePost(clubId, postId, adminId, request);
-
-            // then
-            assertThat(res.postId()).isEqualTo(postId);
-            assertThat(post.getContent()).isEqualTo("admin updated");
-
-            then(clubAuthorizationService).should(times(1))
-                    .assertAtLeastManager(clubId, adminId);
-
-            // imagesUrl = 빈 리스트 => delete만 호출되고 saveAll은 호출 안 됨
-            then(postImageRepository).should(times(1)).deleteByPost_PostId(postId);
-            then(postImageRepository).should(never()).saveAll(anyList());
-
-            // taggedMemberIds = [2,2,3] => delete + saveAll 호출
-            then(postMemberTagRepository).should(times(1)).deleteByPostId(postId);
-            then(postMemberTagRepository).should(times(1)).saveAll(argThat(it -> {
-                List<PostMemberTags> list = StreamSupport.stream(it.spliterator(), false).toList();
-                return list.size() == 2
-                        && list.stream().allMatch(t -> t.getPostId().equals(postId))
-                        && list.stream().map(PostMemberTags::getMemberId).collect(Collectors.toSet())
-                        .containsAll(Set.of(2L, 3L));
-            }));
-        }
-
-        @Test
-        @DisplayName("[ADMIN] 모임 게시글 수정 실패 - 게시글 수정 권한 없음")
-        void update_post_admin() {
-            // given
-            Long clubId = 1L;
-            Long postId = 10L;
-            Long writerId = 100L;
-            Long actorId = 999L; // writer 아님 + 관리자도 아님
-
-            Clubs club = club(clubId);
-            Users writer = user(writerId);
-
-            Posts post = Posts.story(club, writer, null, "old content");
-            ReflectionTestUtils.setField(post, "postId", postId);
-
-            given(postRepository.findByPostIdAndClub_ClubId(postId, clubId))
-                    .willReturn(Optional.of(post));
-
-            willThrow(new ClubException.AuthNoPermission()) // 프로젝트 예외로 교체
-                    .given(clubAuthorizationService)
-                    .assertAtLeastManager(clubId, actorId);
-
-            StoryUpdateRequest request = new StoryUpdateRequest(
-                    "new content", null, null, null
-            );
-
-            // when & then
-            assertThatThrownBy(() -> postService.updatePost(clubId, postId, actorId, request))
-                    .isInstanceOf(ClubException.class);
-
-            then(postImageRepository).shouldHaveNoInteractions();
-            then(postMemberTagRepository).shouldHaveNoInteractions();
-        }
-
-        @Test
-        @DisplayName("[MEMBER] 모임 게시글 수정 실패 - 게시글 수정 권한 없음, 작성자 아님")
-        void update_post_member_not_writer() {
-            // given
-            Long clubId = 1L;
-            Long postId = 10L;
-            Long writerId = 100L;
-            Long memberId = 200L; // writer 아님
-
-            Clubs club = club(clubId);
-            Users writer = user(writerId);
-
-            Posts post = Posts.story(club, writer, null, "old content");
-            ReflectionTestUtils.setField(post, "postId", postId);
-
-            given(postRepository.findByPostIdAndClub_ClubId(postId, clubId))
-                    .willReturn(Optional.of(post));
-
-            willThrow(new ClubException.AuthLoginRequired()) // 프로젝트 예외로 교체
-                    .given(clubAuthorizationService)
-                    .assertAtLeastManager(clubId, memberId);
-
-            List <String> imagesUrl = List.of("example/1", "example/2");
-            StoryUpdateRequest request = new StoryUpdateRequest(
-                    "new content", imagesUrl , null, null
-            );
-
-            // when & then
-            assertThatThrownBy(() -> postService.updatePost(clubId, postId, memberId, request))
-                    .isInstanceOf(ClubException.class);
-
-            then(postImageRepository).shouldHaveNoInteractions();
-            then(postMemberTagRepository).shouldHaveNoInteractions();
-        }
-
-        // ===== 테스트 헬퍼 (테스트 클래스에 이미 있으면 재사용) =====
 
         private Clubs club(Long id) {
-            Clubs c = newEntity(Clubs.class);
-            ReflectionTestUtils.setField(c, "clubId", id);
-            return c;
+                Clubs c = newEntity(Clubs.class);
+                ReflectionTestUtils.setField(c, "clubId", id);
+                return c;
         }
 
         private Users user(Long id) {
-            Users u = newEntity(Users.class);
-            ReflectionTestUtils.setField(u, "userId", id);
-            return u;
+                Users u = newEntity(Users.class);
+                ReflectionTestUtils.setField(u, "userId", id);
+                return u;
         }
 
-        private static <T> T newEntity(Class<T> type) {
-            try {
-                var ctor = type.getDeclaredConstructor();
-                ctor.setAccessible(true);
-                return ctor.newInstance();
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-
-        @Nested
-        class UpdateComment {
-
-            @Test
-            @DisplayName("[MEMBER] 댓글 수정 성공 - 작성자")
-            void update_comment_writer_success() {
-                // given
-                Long clubId = 1L;
-                Long postId = 10L;
-                Long commentId = 100L;
-                Long writerId = 7L;
-
-                PostCommentRequest req = new PostCommentRequest("updated");
-
-                Users writer = newEntity(Users.class);
-                ReflectionTestUtils.setField(writer, "userId", writerId);
-
-                Posts post = newEntity(Posts.class);
-                Comments comment = newEntity(Comments.class);
-                ReflectionTestUtils.setField(comment, "commentId", commentId);
-                ReflectionTestUtils.setField(comment, "post", post);
-                ReflectionTestUtils.setField(comment, "writer", writer);
-                ReflectionTestUtils.setField(comment, "content", "old");
-                ReflectionTestUtils.setField(comment, "deletedAt", null);
-
-                given(postCommentRepository.findByCommentIdAndPost_PostIdAndPost_Club_ClubIdAndDeletedAtIsNull(commentId, postId, clubId))
-                        .willReturn(Optional.of(comment));
-
-                // when
-                PostCommentsIdResponse res = postCommentService.updateComment(writerId, clubId, postId, commentId, req);
-
-                // then
-                assertThat(res.commentId()).isEqualTo(commentId);
-                assertThat(comment.getContent()).isEqualTo("updated");
-                verify(clubAuthorizationService).validateAndGetClubForUpdatePosts(anyLong(), eq(writerId));
-                verifyNoMoreInteractions(clubAuthorizationService);            }
-
-            @Test
-            @DisplayName("[ADMIN] 댓글 수정 성공 - 작성자 아님, 운영진 이상")
-            void update_comment_manager_success() {
-                // given
-                Long clubId = 1L;
-                Long postId = 10L;
-                Long commentId = 100L;
-                Long writerId = 7L;
-                Long managerId = 8L;
-
-                PostCommentRequest req = new PostCommentRequest("updated");
-
-                Users writer = newEntity(Users.class);
-                ReflectionTestUtils.setField(writer, "userId", writerId);
-
-                Comments comment = newEntity(Comments.class);
-                ReflectionTestUtils.setField(comment, "commentId", commentId);
-                ReflectionTestUtils.setField(comment, "writer", writer);
-                ReflectionTestUtils.setField(comment, "content", "old");
-                ReflectionTestUtils.setField(comment, "deletedAt", null);
-
-                given(postCommentRepository.findByCommentIdAndPost_PostIdAndPost_Club_ClubIdAndDeletedAtIsNull(commentId, postId, clubId))
-                        .willReturn(Optional.of(comment));
-
-                willDoNothing().given(clubAuthorizationService)
-                        .assertAtLeastManager(clubId, managerId);
-
-                // when
-                PostCommentsIdResponse res = postCommentService.updateComment(managerId, clubId, postId, commentId, req);
-
-                // then
-                assertThat(res.commentId()).isEqualTo(commentId);
-                assertThat(comment.getContent()).isEqualTo("updated");
-                then(clubAuthorizationService).should(times(1)).assertAtLeastManager(clubId, managerId);
-            }
-
-            @Test
-            @DisplayName("[MEMBER] 댓글 수정 실패 - 작성자 아님, 운영진 권한도 없음")
-            void update_comment_forbidden() {
-                // given
-                Long clubId = 1L;
-                Long postId = 10L;
-                Long commentId = 100L;
-                Long writerId = 7L;
-                Long actorId = 9L;
-
-                PostCommentRequest req = new PostCommentRequest("updated");
-
-                Users writer = newEntity(Users.class);
-                ReflectionTestUtils.setField(writer, "userId", writerId);
-
-                Comments comment = newEntity(Comments.class);
-                ReflectionTestUtils.setField(comment, "commentId", commentId);
-                ReflectionTestUtils.setField(comment, "writer", writer);
-                ReflectionTestUtils.setField(comment, "content", "old");
-                ReflectionTestUtils.setField(comment, "deletedAt", null);
-
-                given(postCommentRepository.findByCommentIdAndPost_PostIdAndPost_Club_ClubIdAndDeletedAtIsNull(commentId, postId, clubId))
-                        .willReturn(Optional.of(comment));
-
-                willThrow(new ClubException.AuthLoginRequired()) // 프로젝트 예외로 교체
-                        .given(clubAuthorizationService)
-                        .assertAtLeastManager(clubId, actorId);
-
-                // when & then
-                assertThatThrownBy(() -> postCommentService.updateComment(actorId, clubId, postId, commentId, req))
-                        .isInstanceOf(ClubException.class);
-
-                assertThat(comment.getContent()).isEqualTo("old");
-            }
-
-            @Test
-            @DisplayName("댓글 수정 실패 - 이미 삭제된 댓글")
-            void update_deleted_comment_fail() {
-                // given
-                Long clubId = 1L;
-                Long postId = 10L;
-                Long commentId = 100L;
-                Long actorId = 7L;
-
-                PostCommentRequest req = new PostCommentRequest("updated");
-
-                Users writer = newEntity(Users.class);
-                ReflectionTestUtils.setField(writer, "userId", actorId);
-
-                Comments comment = newEntity(Comments.class);
-                ReflectionTestUtils.setField(comment, "commentId", commentId);
-                ReflectionTestUtils.setField(comment, "writer", writer);
-                ReflectionTestUtils.setField(comment, "content", "old");
-                ReflectionTestUtils.setField(comment, "deletedAt", LocalDateTime.now()); // 삭제됨
-
-                given(postCommentRepository
-                        .findByCommentIdAndPost_PostIdAndPost_Club_ClubIdAndDeletedAtIsNull(commentId, postId, clubId))
-                        .willReturn(Optional.empty());
-
-                assertThatThrownBy(() -> postCommentService.updateComment(actorId, clubId, postId, commentId, req))
-                        .isInstanceOf(PostsException.PostCommentNotFound.class); // 또는 CommentNotFound
-            }
-
-            private static <T> T newEntity(Class<T> type) {
-                try {
-                    var ctor = type.getDeclaredConstructor();
-                    ctor.setAccessible(true);
-                    return ctor.newInstance();
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
-            }
-        }
-
-    }
-
-
-    @Nested
-    class DeletePost { /* 삭제 */
-
-        @Test
-        @DisplayName("[MEMBER] 모임 게시글 삭제 성공")
-        void delete_post_member() {
-            // given
-            Long clubId = 1L;
-            Long postId = 10L;
-            Long writerId = 100L; // 작성자
-
-            Clubs club = club(clubId);
-            Users writer = user(writerId);
-
-            Posts post = Posts.story(club, writer, null, "content");
-            ReflectionTestUtils.setField(post, "postId", postId);
-
-            given(postRepository.findByPostIdAndClub_ClubId(postId, clubId))
-                    .willReturn(Optional.of(post));
-
-            // when
-            postService.deletePost(clubId, postId, writerId);
-
-            // then
-            assertThat(post.getDeletedAt()).isNotNull();
-
-            // 작성자면 매니저 체크 안 탐
-            then(clubAuthorizationService).shouldHaveNoInteractions();
-            then(postRepository).should(times(1)).findByPostIdAndClub_ClubId(postId, clubId);
-        }
-
-        @Test
-        @DisplayName("[MEMBER] 모임 게시글 삭제 실패 - 게시글 삭제 권한 없음, 작성자 아님")
-        void delete_post_guest() {
-            // given
-            Long clubId = 1L;
-            Long postId = 10L;
-            Long writerId = 100L;
-            Long memberId = 200L; // 작성자 아님
-
-            Clubs club = club(clubId);
-            Users writer = user(writerId);
-
-            Posts post = Posts.story(club, writer, null, "content");
-            ReflectionTestUtils.setField(post, "postId", postId);
-
-            given(postRepository.findByPostIdAndClub_ClubId(postId, clubId))
-                    .willReturn(Optional.of(post));
-
-            willThrow(new ClubException.AuthLoginRequired()) // 프로젝트 예외로 교체
-                    .given(clubAuthorizationService)
-                    .assertAtLeastManager(clubId, memberId);
-
-            // when & then
-            assertThatThrownBy(() -> postService.deletePost(clubId, postId, memberId))
-                    .isInstanceOf(ClubException.class);
-
-            // delete 안 됨
-            assertThat(post.getDeletedAt()).isNull();
-            then(clubAuthorizationService).should(times(1)).assertAtLeastManager(clubId, memberId);
-        }
-
-        // ===== 테스트 헬퍼 (이미 있으면 재사용) =====
-        private Clubs club(Long id) {
-            Clubs c = newEntity(Clubs.class);
-            ReflectionTestUtils.setField(c, "clubId", id);
-            return c;
-        }
-
-        private Users user(Long id) {
-            Users u = newEntity(Users.class);
-            ReflectionTestUtils.setField(u, "userId", id);
-            return u;
-        }
-
-        private static <T> T newEntity(Class<T> type) {
-            try {
-                var ctor = type.getDeclaredConstructor();
-                ctor.setAccessible(true);
-                return ctor.newInstance();
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
+        private Schedules schedule(Long id) {
+                Schedules s = newEntity(Schedules.class);
+                ReflectionTestUtils.setField(s, "scheduleId", id);
+                return s;
         }
 
         @Nested
-        class DeleteComment {
+        @DisplayName("모임 게시글 전체 조회")
+        class ListPosts { /* 목록 */
 
-            @Test
-            @DisplayName("[MEMBER] 댓글 삭제 성공 - 작성자")
-            void delete_comment_writer_success() {
-                // given
-                Long clubId = 1L;
-                Long postId = 10L;
-                Long commentId = 100L;
-                Long writerId = 7L;
+                @Test
+                @DisplayName("[GUEST] 공개 모임 게시글 조회 성공")
+                void list_club_public_posts_public() {
+                        // given
+                        Long clubId = 1L;
+                        Long viewerId = null; // 게스트면 null 쓰는 정책이면
+                        Pageable pageable = PageRequest.of(0, 10);
 
-                Users writer = newEntity(Users.class);
-                ReflectionTestUtils.setField(writer, "userId", writerId);
+                        // 권한 통과 스텁
+                        willDoNothing().given(clubAuthorizationService)
+                                        .validateAndGetClubForReadPosts(clubId, viewerId);
 
-                Comments comment = newEntity(Comments.class);
-                ReflectionTestUtils.setField(comment, "commentId", commentId);
-                ReflectionTestUtils.setField(comment, "writer", writer);
-                ReflectionTestUtils.setField(comment, "deletedAt", null);
+                        // repository가 반환하는 projection mock
+                        PostCardBase p1 = mock(PostCardBase.class);
+                        given(p1.postId()).willReturn(1L);
+                        PostCardBase p2 = mock(PostCardBase.class);
+                        given(p2.postId()).willReturn(2L);
 
-                given(postCommentRepository.findByCommentIdAndPost_PostIdAndPost_Club_ClubIdAndDeletedAtIsNull(commentId, postId, clubId))
-                        .willReturn(Optional.of(comment));
+                        given(postRepository.findPostCards(eq(clubId), eq(pageable)))
+                                        .willReturn(new PageImpl<>(List.of(p1, p2), pageable, 2));
 
-                // when
-                PostCommentsIdResponse res = postCommentService.deleteComment(writerId, clubId, postId, commentId);
+                        // 이미지 조회 스텁
+                        PostImages img1 = mock(PostImages.class);
+                        given(img1.getPostId()).willReturn(1L);
+                        given(img1.getImageUrl()).willReturn("https://example.com/1.png");
 
-                // then
-                assertThat(res.commentId()).isEqualTo(commentId);
-                assertThat(comment.getDeletedAt()).isNotNull(); // soft delete 확인
-                verify(clubAuthorizationService).validateAndGetClubForUpdatePosts(anyLong(), eq(writerId));
-                verifyNoMoreInteractions(clubAuthorizationService);
+                        given(postImageRepository.findByPostIdIn(List.of(1L, 2L)))
+                                        .willReturn(List.of(img1));
 
-            }
+                        // when
+                        List<PostCardResponse> result = postService.getRecentPosts(clubId, viewerId, pageable);
 
-            @Test
-            @DisplayName("[ADMIN] 댓글 삭제 성공 - 작성자 아님, 운영진 이상")
-            void delete_comment_manager_success() {
-                // given
-                Long clubId = 1L;
-                Long postId = 10L;
-                Long commentId = 100L;
-                Long writerId = 7L;
-                Long managerId = 8L;
-
-                Users writer = newEntity(Users.class);
-                ReflectionTestUtils.setField(writer, "userId", writerId);
-
-                Comments comment = newEntity(Comments.class);
-                ReflectionTestUtils.setField(comment, "commentId", commentId);
-                ReflectionTestUtils.setField(comment, "writer", writer);
-                ReflectionTestUtils.setField(comment, "deletedAt", null);
-
-                given(postCommentRepository.findByCommentIdAndPost_PostIdAndPost_Club_ClubIdAndDeletedAtIsNull(commentId, postId, clubId))
-                        .willReturn(Optional.of(comment));
-
-                willDoNothing().given(clubAuthorizationService)
-                        .assertAtLeastManager(clubId, managerId);
-
-                // when
-                PostCommentsIdResponse res = postCommentService.deleteComment(managerId, clubId, postId, commentId);
-
-                // then
-                assertThat(res.commentId()).isEqualTo(commentId);
-                assertThat(comment.getDeletedAt()).isNotNull();
-                then(clubAuthorizationService).should(times(1)).assertAtLeastManager(clubId, managerId);
-            }
-
-            @Test
-            @DisplayName("[MEMBER] 댓글 삭제 실패 - 작성자 아님, 운영진 권한도 없음")
-            void delete_comment_forbidden() {
-                // given
-                Long clubId = 1L;
-                Long postId = 10L;
-                Long commentId = 100L;
-                Long writerId = 7L;
-                Long actorId = 9L;
-
-                Users writer = newEntity(Users.class);
-                ReflectionTestUtils.setField(writer, "userId", writerId);
-
-                Comments comment = newEntity(Comments.class);
-                ReflectionTestUtils.setField(comment, "commentId", commentId);
-                ReflectionTestUtils.setField(comment, "writer", writer);
-                ReflectionTestUtils.setField(comment, "deletedAt", null);
-
-                given(postCommentRepository.findByCommentIdAndPost_PostIdAndPost_Club_ClubIdAndDeletedAtIsNull(commentId, postId, clubId))
-                        .willReturn(Optional.of(comment));
-
-                willThrow(new ClubException.AuthLoginRequired()) // 프로젝트 예외로 교체
-                        .given(clubAuthorizationService)
-                        .assertAtLeastManager(clubId, actorId);
-
-                // when & then
-                assertThatThrownBy(() -> postCommentService.deleteComment(actorId, clubId, postId, commentId))
-                        .isInstanceOf(ClubException.class);
-
-                assertThat(comment.getDeletedAt()).isNull(); // 삭제 안 됨
-            }
-
-            @Test
-            @DisplayName("댓글 삭제 멱등 - 이미 삭제된 댓글은 다시 삭제해도 성공")
-            void delete_comment_idempotent_when_already_deleted() {
-                // given
-                Long clubId = 1L;
-                Long postId = 10L;
-                Long commentId = 100L;
-                Long actorId = 7L;
-
-                Users writer = newEntity(Users.class);
-                ReflectionTestUtils.setField(writer, "userId", 999L); // actor가 작성자 아니어도 상관 없음(이미 삭제면 return)
-
-                Comments comment = newEntity(Comments.class);
-                ReflectionTestUtils.setField(comment, "commentId", commentId);
-                ReflectionTestUtils.setField(comment, "writer", writer);
-                ReflectionTestUtils.setField(comment, "deletedAt", LocalDateTime.now()); // 이미 삭제됨
-
-                given(postCommentRepository.findByCommentIdAndPost_PostIdAndPost_Club_ClubIdAndDeletedAtIsNull(commentId, postId, clubId))
-                        .willReturn(Optional.of(comment));
-
-                // when
-                PostCommentsIdResponse res = postCommentService.deleteComment(actorId, clubId, postId, commentId);
-
-                // then
-                assertThat(res.commentId()).isEqualTo(commentId);
-                then(clubAuthorizationService).shouldHaveNoInteractions(); // 멱등 return이라 권한 체크 안 타는 게 깔끔
-            }
-
-            private static <T> T newEntity(Class<T> type) {
-                try {
-                    var ctor = type.getDeclaredConstructor();
-                    ctor.setAccessible(true);
-                    return ctor.newInstance();
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
+                        // then
+                        assertThat(result).hasSize(2);
+                        then(clubAuthorizationService).should().validateAndGetClubForReadPosts(clubId, viewerId);
+                        then(postRepository).should().findPostCards(clubId, pageable);
+                        then(postImageRepository).should().findByPostIdIn(List.of(1L, 2L));
                 }
-            }
+
+                @Test
+                @DisplayName("[GUEST] 비공개 모임 게시글 조회 실패")
+                void list_club_public_posts_private() {
+                        // given
+                        Long clubId = 1L;
+                        Long viewerId = null; // 게스트
+                        Pageable pageable = PageRequest.of(0, 10);
+
+                        willThrow(new ClubException.AuthLoginRequired()) // 프로젝트 예외로 교체
+                                        .given(clubAuthorizationService)
+                                        .validateAndGetClubForReadPosts(clubId, viewerId);
+
+                        // when & then
+                        assertThatThrownBy(() -> postService.getRecentPosts(clubId, viewerId, pageable))
+                                        .isInstanceOf(ClubException.class);
+
+                        then(postRepository).shouldHaveNoInteractions();
+                        then(postImageRepository).shouldHaveNoInteractions();
+                }
+
+                @Test
+                @DisplayName("[MEMBER] 비공개 모임 게시글 조회 성공")
+                void list_club_private() {
+                        // given
+                        Long clubId = 1L;
+                        Long viewerId = 10L; // 멤버
+                        Pageable pageable = PageRequest.of(0, 10);
+
+                        willDoNothing().given(clubAuthorizationService)
+                                        .validateAndGetClubForReadPosts(clubId, viewerId);
+
+                        PostCardBase p1 = mock(PostCardBase.class);
+                        given(p1.postId()).willReturn(1L);
+
+                        given(postRepository.findPostCards(eq(clubId), eq(pageable)))
+                                        .willReturn(new PageImpl<>(List.of(p1), pageable, 1));
+
+                        given(postImageRepository.findByPostIdIn(List.of(1L)))
+                                        .willReturn(List.of()); // 이미지 없는 케이스
+
+                        // when
+                        List<PostCardResponse> result = postService.getRecentPosts(clubId, viewerId, pageable);
+
+                        // then
+                        assertThat(result).hasSize(1);
+
+                        then(clubAuthorizationService).should().validateAndGetClubForReadPosts(clubId, viewerId);
+                        then(postRepository).should().findPostCards(clubId, pageable);
+                        then(postImageRepository).should().findByPostIdIn(List.of(1L));
+                }
         }
-    }
+
+        @Nested
+        class GetPostDetail { /* 상세 조회 */
+
+                @Test
+                @DisplayName("[GUEST] 공개 모임 게시글 상세 조회 성공")
+                void get_post_public() {
+                        // given
+                        Long clubId = 1L;
+                        Long postId = 1L;
+                        Long viewerId = null;
+
+                        willDoNothing().given(clubAuthorizationService)
+                                        .validateAndGetClubForReadPosts(clubId, viewerId);
+
+                        Clubs club = newEntity(Clubs.class);
+                        ReflectionTestUtils.setField(club, "clubId", clubId);
+
+                        Users writer = newEntity(Users.class);
+                        ReflectionTestUtils.setField(writer, "userId", 10L);
+
+                        Schedules schedule = newEntity(Schedules.class);
+                        ReflectionTestUtils.setField(schedule, "scheduleId", 100L);
+
+                        Posts post = Posts.story(club, writer, schedule, "hello content");
+                        ReflectionTestUtils.setField(post, "postId", postId);
+
+                        given(postRepository.findByPostIdAndClub_ClubId(postId, clubId))
+                                        .willReturn(Optional.of(post));
+
+                        // when
+                        PostDetailResponse res = postService.getPost(clubId, postId, viewerId);
+
+                        // then
+                        assertThat(res).isNotNull();
+                        assertThat(res.postId()).isEqualTo(postId);
+                        assertThat(res.clubId()).isEqualTo(clubId);
+                        assertThat(res.writerId()).isEqualTo(10L);
+                        assertThat(res.scheduleId()).isEqualTo(100L);
+
+                        then(clubAuthorizationService).should(times(1))
+                                        .validateAndGetClubForReadPosts(clubId, viewerId);
+                        then(postRepository).should(times(1))
+                                        .findByPostIdAndClub_ClubId(postId, clubId);
+                }
+
+                @Test
+                @DisplayName("[MEMBER] 게시글 상세 조회 실패 - 없는 게시글")
+                void get_no_post_member() {
+                        // given
+                        Long clubId = 1L;
+                        Long postId = 999L;
+                        Long viewerId = 100L;
+
+                        willDoNothing().given(clubAuthorizationService)
+                                        .validateAndGetClubForReadPosts(clubId, viewerId);
+
+                        given(postRepository.findByPostIdAndClub_ClubId(postId, clubId))
+                                        .willReturn(Optional.empty());
+
+                        // when & then
+                        assertThatThrownBy(() -> postService.getPost(clubId, postId, viewerId))
+                                        .isInstanceOf(PostsException.PostNotFound.class);
+                }
+
+                @Test
+                @DisplayName("[GUEST] 공개 모임 게시글 상세 조회 실패 - 비공개 게시글")
+                void get_post_private_guest() {
+                        // given
+                        Long clubId = 1L;
+                        Long postId = 1L;
+                        Long viewerId = null; // 게스트 정책이면 null
+
+                        willThrow(new ClubException.AuthLoginRequired()) // 프로젝트 예외로 교체
+                                        .given(clubAuthorizationService)
+                                        .validateAndGetClubForReadPosts(clubId, viewerId);
+
+                        // when & then
+                        assertThatThrownBy(() -> postService.getPost(clubId, postId, viewerId))
+                                        .isInstanceOf(ClubException.class);
+
+                        then(postRepository).shouldHaveNoInteractions();
+                }
+
+                @Test
+                @DisplayName("[MEMBER] 비공개 모임 게시글 상세 조회 성공")
+                void get_post_private_member() {
+                        // given
+                        Long clubId = 1L;
+                        Long postId = 10L;
+                        Long viewerId = 100L; // 멤버
+
+                        willDoNothing().given(clubAuthorizationService)
+                                        .validateAndGetClubForReadPosts(clubId, viewerId);
+
+                        Clubs club = newEntity(Clubs.class);
+                        ReflectionTestUtils.setField(club, "clubId", clubId);
+
+                        Users writer = newEntity(Users.class);
+                        ReflectionTestUtils.setField(writer, "userId", 200L);
+
+                        Posts post = Posts.story(club, writer, null, "content");
+                        ReflectionTestUtils.setField(post, "postId", postId);
+
+                        given(postRepository.findByPostIdAndClub_ClubId(postId, clubId))
+                                        .willReturn(Optional.of(post));
+
+                        // when
+                        PostDetailResponse res = postService.getPost(clubId, postId, viewerId);
+
+                        // then
+                        assertThat(res).isNotNull();
+                        assertThat(res.postId()).isEqualTo(postId);
+
+                        then(clubAuthorizationService).should(times(1))
+                                        .validateAndGetClubForReadPosts(clubId, viewerId);
+                        then(postRepository).should(times(1))
+                                        .findByPostIdAndClub_ClubId(postId, clubId);
+                }
+
+                @Nested
+                @DisplayName("게시글 내 댓글 전체 조회")
+                class GetComments {
+
+                        @Mock
+                        private ClubAuthService clubAuthorizationService;
+                        @Mock
+                        private PostRepository postRepository;
+                        @Mock
+                        private PostCommentRepository postCommentRepository;
+                        @Mock
+                        private UserRepository userRepository;
+                        @Mock
+                        private org.springframework.context.ApplicationEventPublisher eventPublisher;
+
+                        @InjectMocks
+                        private PostCommentService postCommentService;
+
+                        @Test
+                        @DisplayName("[GUEST] 공개 모임 댓글 조회 성공 - 페이징 메타 포함")
+                        void get_comments_public_guest_success() {
+                                // given
+                                Long clubId = 1L;
+                                Long postId = 10L;
+                                Long viewerId = null;
+
+                                Pageable pageable = PageRequest.of(0, 2, Sort.by(Sort.Direction.ASC, "createdAt"));
+
+                                willDoNothing().given(clubAuthorizationService)
+                                                .validateAndGetClubForReadPosts(clubId, viewerId);
+
+                                Users w1 = newEntity(Users.class);
+                                ReflectionTestUtils.setField(w1, "userId", 100L);
+
+                                Comments c1 = newEntity(Comments.class);
+                                ReflectionTestUtils.setField(c1, "commentId", 1L);
+                                ReflectionTestUtils.setField(c1, "writer", w1);
+                                ReflectionTestUtils.setField(c1, "content", "a");
+                                ReflectionTestUtils.setField(c1, "createdAt", LocalDateTime.now());
+
+                                Users w2 = newEntity(Users.class);
+                                ReflectionTestUtils.setField(w2, "userId", 200L);
+
+                                Comments c2 = newEntity(Comments.class);
+                                ReflectionTestUtils.setField(c2, "commentId", 2L);
+                                ReflectionTestUtils.setField(c2, "writer", w2);
+                                ReflectionTestUtils.setField(c2, "content", "b");
+                                ReflectionTestUtils.setField(c2, "createdAt", LocalDateTime.now());
+
+                                // total=5면 hasNext=true (page=0, size=2)
+                                Page<Comments> page = new PageImpl<>(List.of(c1, c2), pageable, 5);
+
+                                given(postCommentRepository.findAllByPost_PostIdAndPost_Club_ClubIdAndDeletedAtIsNull(
+                                                postId, clubId, pageable)).willReturn(page);
+
+                                // when
+                                PostCommentsResponse res = postCommentService.getPostComments(viewerId, clubId, postId,
+                                                pageable);
+
+                                // then
+                                assertThat(res.comments()).hasSize(2);
+                                assertThat(res.page()).isEqualTo(0);
+                                assertThat(res.size()).isEqualTo(2);
+                                assertThat(res.totalElements()).isEqualTo(5);
+                                assertThat(res.totalPages()).isEqualTo(3);
+                                assertThat(res.hasNext()).isTrue();
+
+                                assertThat(res.comments().getFirst().commentId()).isEqualTo(1L);
+                                assertThat(res.comments().getFirst().writerId()).isEqualTo(100L);
+                                assertThat(res.comments().getFirst().content()).isEqualTo("a");
+
+                                then(clubAuthorizationService).should(times(1))
+                                                .validateAndGetClubForReadPosts(clubId, viewerId);
+                                then(postCommentRepository).should(times(1))
+                                                .findAllByPost_PostIdAndPost_Club_ClubIdAndDeletedAtIsNull(postId,
+                                                                clubId, pageable);
+                        }
+
+                        @Test
+                        @DisplayName("[MEMBER] 댓글 조회 성공 - 결과 없음")
+                        void get_comments_empty() {
+                                // given
+                                Long clubId = 1L;
+                                Long postId = 10L;
+                                Long viewerId = 100L;
+
+                                Pageable pageable = PageRequest.of(0, 20);
+
+                                willDoNothing().given(clubAuthorizationService)
+                                                .validateAndGetClubForReadPosts(clubId, viewerId);
+
+                                Page<Comments> empty = Page.empty(pageable);
+
+                                given(postCommentRepository.findAllByPost_PostIdAndPost_Club_ClubIdAndDeletedAtIsNull(
+                                                postId, clubId, pageable)).willReturn(empty);
+
+                                // when
+                                PostCommentsResponse res = postCommentService.getPostComments(viewerId, clubId, postId,
+                                                pageable);
+
+                                // then
+                                assertThat(res.comments()).isEmpty();
+                                assertThat(res.hasNext()).isFalse();
+                                assertThat(res.totalElements()).isEqualTo(0);
+                        }
+
+                        @Test
+                        @DisplayName("[GUEST] 비공개 모임 댓글 조회 실패 - 권한 없음")
+                        void get_comments_private_guest_fail() {
+                                // given
+                                Long clubId = 1L;
+                                Long postId = 10L;
+                                Long viewerId = null;
+
+                                Pageable pageable = PageRequest.of(0, 20);
+
+                                willThrow(new ClubException.AuthLoginRequired()) // 프로젝트 예외로 교체
+                                                .given(clubAuthorizationService)
+                                                .validateAndGetClubForReadPosts(clubId, viewerId);
+
+                                // when & then
+                                assertThatThrownBy(() -> postCommentService.getPostComments(viewerId, clubId, postId,
+                                                pageable))
+                                                .isInstanceOf(ClubException.class);
+
+                                then(postCommentRepository).shouldHaveNoInteractions();
+                        }
+
+                        private static <T> T newEntity(Class<T> type) {
+                                try {
+                                        var ctor = type.getDeclaredConstructor();
+                                        ctor.setAccessible(true);
+                                        return ctor.newInstance();
+                                } catch (Exception e) {
+                                        throw new RuntimeException(e);
+                                }
+                        }
+                }
+
+                @Nested
+                @DisplayName("게시글 내 좋아요 수 조회")
+                class getLikes {
+                }
+        }
+
+        @Nested
+        class CreatePost { /* 게시글 생성 */
+
+                @Test
+                @DisplayName("[MEMBER] 모임 게시글 생성 성공 - 이미지/태그 없음")
+                void create_post_member_success_without_images_tags() {
+                        Long clubId = 1L;
+                        Long writerId = 1L;
+
+                        StoryCreateRequest request = new StoryCreateRequest(
+                                        null,
+                                        "모임 게시글 생성",
+                                        null,
+                                        "  남한산성  ",
+                                        null);
+
+                        Clubs clubRef = club(clubId);
+                        Users writerRef = user(writerId);
+
+                        given(clubsRepository.getReferenceById(clubId)).willReturn(clubRef);
+                        given(userRepository.getReferenceById(writerId)).willReturn(writerRef);
+
+                        Posts savedPost = Posts.story(clubRef, writerRef, null, request.content());
+                        ReflectionTestUtils.setField(savedPost, "postId", 10L);
+
+                        given(postRepository.save(any(Posts.class))).willReturn(savedPost);
+
+                        PostIdResponse res = postService.createStory(clubId, writerId, request);
+
+                        assertThat(res.postId()).isEqualTo(10L);
+
+                        then(postRepository).should(times(1)).save(any(Posts.class));
+                        then(postImageRepository).shouldHaveNoInteractions();
+                        then(postMemberTagRepository).shouldHaveNoInteractions();
+                }
+
+                @Test
+                @DisplayName("[MEMBER] 모임 게시글 생성 성공 - 이미지/태그 저장 포함")
+                void create_post_member_success_with_images_tags() {
+                        Long clubId = 1L;
+                        Long writerId = 1L;
+
+                        StoryCreateRequest request = new StoryCreateRequest(
+                                        1L,
+                                        "모임 게시글 생성",
+                                        List.of("https://example.com/1.png", "https://example.com/2.png"),
+                                        "강남역",
+                                        List.of(2L, 3L));
+
+                        Clubs clubRef = club(clubId);
+                        Users writerRef = user(writerId);
+                        Schedules scheduleRef = schedule(1L);
+
+                        given(clubsRepository.getReferenceById(clubId)).willReturn(clubRef);
+                        given(userRepository.getReferenceById(writerId)).willReturn(writerRef);
+                        given(scheduleRepository.getReferenceById(1L)).willReturn(scheduleRef);
+
+                        Posts savedPost = Posts.story(clubRef, writerRef, scheduleRef, request.content());
+                        ReflectionTestUtils.setField(savedPost, "postId", 1L);
+
+                        given(postRepository.save(any(Posts.class))).willReturn(savedPost);
+
+                        PostIdResponse res = postService.createStory(clubId, writerId, request);
+
+                        assertThat(res.postId()).isEqualTo(1L);
+
+                        then(postImageRepository).should(times(1)).deleteByPost_PostId(1L);
+                        then(postImageRepository).should(times(1)).saveAll(anyList());
+
+                        then(postMemberTagRepository).should(times(1)).deleteByPostId(1L);
+                        then(postMemberTagRepository).should(times(1)).saveAll(anyList());
+                }
+
+                @Test
+                @DisplayName("[GUEST] 모임 게시글 생성 실패 - 게시글 생성 권한 없음")
+                void create_post_guest() {
+                        // given
+                        Long clubId = 1L;
+                        Long writerId = 999L; // 게스트/비회원 가정
+
+                        StoryCreateRequest request = new StoryCreateRequest(
+                                        null,
+                                        "content",
+                                        null,
+                                        null,
+                                        null);
+
+                        willThrow(new ClubException.AuthLoginRequired()) // 프로젝트 예외로 교체
+                                        .given(clubAuthorizationService)
+                                        .assertActiveMember(clubId, writerId);
+
+                        // when & then
+                        assertThatThrownBy(() -> postService.createStory(clubId, writerId, request))
+                                        .isInstanceOf(ClubException.class);
+
+                        then(postRepository).shouldHaveNoInteractions();
+                        then(postImageRepository).shouldHaveNoInteractions();
+                        then(postMemberTagRepository).shouldHaveNoInteractions();
+                }
+
+                @Nested
+                class CreateComment {
+
+                        @Mock
+                        private ClubAuthService clubAuthorizationService;
+                        @Mock
+                        private PostRepository postRepository;
+                        @Mock
+                        private PostCommentRepository postCommentRepository;
+                        @Mock
+                        private UserRepository userRepository;
+                        @Mock
+                        private ApplicationEventPublisher eventPublisher;
+
+                        private PostCommentService postCommentService;
+
+                        @org.junit.jupiter.api.BeforeEach
+                        void setUp() {
+                                postCommentService = new PostCommentService(
+                                                postCommentRepository,
+                                                userRepository,
+                                                postRepository,
+                                                clubAuthorizationService,
+                                                eventPublisher);
+                        }
+
+                        @Test
+                        @DisplayName("[MEMBER] 댓글 생성 성공 - id 반환")
+                        void create_comment_member_success() {
+                                // given
+                                Long clubId = 1L;
+                                Long postId = 10L;
+                                Long writerId = 100L;
+
+                                PostCommentRequest req = new PostCommentRequest("hi");
+
+                                willDoNothing().given(clubAuthorizationService)
+                                                .assertActiveMember(clubId, writerId);
+
+                                // posts 존재 확인을 한다면(서비스 구현에 따라)
+                                // posts 존재 확인을 한다면(서비스 구현에 따라)
+                                Posts postRef = newEntity(Posts.class);
+                                ReflectionTestUtils.setField(postRef, "postId", postId);
+
+                                Users writerRef = newEntity(Users.class);
+                                ReflectionTestUtils.setField(writerRef, "userId", writerId); // 작성자 ID 설정
+
+                                // 추가: userRepository 스터빙
+                                given(userRepository.getReferenceById(writerId)).willReturn(writerRef);
+
+                                // Post의 작성자도 설정 필요 (이벤트 로직에서 사용 - getPost().getWriter().getUserId())
+                                // 하지만 여기선 댓글 작성자가 아닌 게시글 작성자가 필요함.
+                                Users postWriterRef = newEntity(Users.class);
+                                ReflectionTestUtils.setField(postWriterRef, "userId", 200L); // 게시글 작성자
+                                ReflectionTestUtils.setField(postRef, "writer", postWriterRef);
+
+                                given(postRepository.getReferenceById(postId)).willReturn(postRef);
+
+                                Comments saved = newEntity(Comments.class);
+                                ReflectionTestUtils.setField(saved, "commentId", 55L);
+                                ReflectionTestUtils.setField(saved, "post", postRef); // 댓글 -> 게시글
+                                ReflectionTestUtils.setField(saved, "writer", writerRef); // 댓글 -> 작성자 (이벤트 로직에서
+                                                                                          // comments.getContent() 사용)
+                                // content도 설정
+                                ReflectionTestUtils.setField(saved, "content", "hi");
+
+                                given(postCommentRepository.save(any(Comments.class))).willReturn(saved);
+
+                                // when
+                                PostCommentsIdResponse res = postCommentService.createComment(writerId, clubId, postId,
+                                                req);
+
+                                // then
+                                assertThat(res.commentId()).isEqualTo(55L);
+                                verify(clubAuthorizationService).assertActiveMember(anyLong(), eq(writerId));
+                                verifyNoMoreInteractions(clubAuthorizationService);
+                        }
+
+                        @Test
+                        @DisplayName("[GUEST] 댓글 생성 실패 - 권한 없음")
+                        void create_comment_guest_fail() {
+                                // given
+                                Long clubId = 1L;
+                                Long postId = 10L;
+                                Long writerId = 999L;
+
+                                PostCommentRequest req = new PostCommentRequest("hi");
+
+                                willThrow(new ClubException.AuthLoginRequired()) // 프로젝트 예외로 교체
+                                                .given(clubAuthorizationService)
+                                                .assertActiveMember(clubId, writerId);
+
+                                // when & then
+                                assertThatThrownBy(
+                                                () -> postCommentService.createComment(writerId, clubId, postId, req))
+                                                .isInstanceOf(ClubException.class);
+
+                                then(postCommentRepository).shouldHaveNoInteractions();
+                        }
+                }
+
+                @Nested
+                class CreateLike {
+                }
+        }
+
+        @Nested
+        class UpdatePost { /* 수정 */
+
+                @Test
+                @DisplayName("[MEMBER] 모임 게시글 수정 성공")
+                void update_post_member() {
+                        // given
+                        Long clubId = 1L;
+                        Long postId = 10L;
+                        Long writerId = 100L; // actor == writer
+
+                        Clubs club = club(clubId);
+                        Users writer = user(writerId);
+
+                        Posts post = Posts.story(club, writer, null, "old content");
+                        ReflectionTestUtils.setField(post, "postId", postId);
+
+                        given(postRepository.findByPostIdAndClub_ClubId(postId, clubId))
+                                        .willReturn(Optional.of(post));
+
+                        StoryUpdateRequest request = new StoryUpdateRequest(
+                                        "new content",
+                                        null,
+                                        null,
+                                        null);
+
+                        // when
+                        PostIdResponse res = postService.updatePost(clubId, postId, writerId, request);
+
+                        // then
+                        assertThat(res.postId()).isEqualTo(postId);
+                        assertThat(post.getContent()).isEqualTo("new content");
+                        assertThat(post.getPlace()).isEqualTo(null);
+
+                        then(clubAuthorizationService).shouldHaveNoInteractions(); // 작성자면 매니저 체크 안 탐
+                        then(postImageRepository).shouldHaveNoInteractions();
+                        then(postMemberTagRepository).shouldHaveNoInteractions();
+                }
+
+                @Test
+                @DisplayName("[ADMIN] 모임 게시글 수정 성공")
+                void update_post_admin_ban() {
+                        // given
+                        Long clubId = 1L;
+                        Long postId = 10L;
+                        Long writerId = 100L;
+                        Long adminId = 999L; // actor != writer
+
+                        Clubs club = club(clubId);
+                        Users writer = user(writerId);
+
+                        Posts post = Posts.story(club, writer, null, "old content");
+                        ReflectionTestUtils.setField(post, "postId", postId);
+
+                        given(postRepository.findByPostIdAndClub_ClubId(postId, clubId))
+                                        .willReturn(Optional.of(post));
+
+                        // 관리자 이상 허용
+                        willDoNothing().given(clubAuthorizationService)
+                                        .assertAtLeastManager(clubId, adminId);
+
+                        StoryUpdateRequest request = new StoryUpdateRequest(
+                                        "admin updated",
+                                        List.of(), // 빈 리스트면 전체 삭제(= delete 호출) 기대
+                                        null,
+                                        List.of(2L, 2L, 3L) // 중복 포함 -> distinct 후 저장
+                        );
+
+                        // when
+                        PostIdResponse res = postService.updatePost(clubId, postId, adminId, request);
+
+                        // then
+                        assertThat(res.postId()).isEqualTo(postId);
+                        assertThat(post.getContent()).isEqualTo("admin updated");
+
+                        then(clubAuthorizationService).should(times(1))
+                                        .assertAtLeastManager(clubId, adminId);
+
+                        // imagesUrl = 빈 리스트 => delete만 호출되고 saveAll은 호출 안 됨
+                        then(postImageRepository).should(times(1)).deleteByPost_PostId(postId);
+                        then(postImageRepository).should(never()).saveAll(anyList());
+
+                        // taggedMemberIds = [2,2,3] => delete + saveAll 호출
+                        then(postMemberTagRepository).should(times(1)).deleteByPostId(postId);
+                        then(postMemberTagRepository).should(times(1)).saveAll(argThat(it -> {
+                                List<PostMemberTags> list = StreamSupport.stream(it.spliterator(), false).toList();
+                                return list.size() == 2
+                                                && list.stream().allMatch(t -> t.getPostId().equals(postId))
+                                                && list.stream().map(PostMemberTags::getMemberId)
+                                                                .collect(Collectors.toSet())
+                                                                .containsAll(Set.of(2L, 3L));
+                        }));
+                }
+
+                @Test
+                @DisplayName("[ADMIN] 모임 게시글 수정 실패 - 게시글 수정 권한 없음")
+                void update_post_admin() {
+                        // given
+                        Long clubId = 1L;
+                        Long postId = 10L;
+                        Long writerId = 100L;
+                        Long actorId = 999L; // writer 아님 + 관리자도 아님
+
+                        Clubs club = club(clubId);
+                        Users writer = user(writerId);
+
+                        Posts post = Posts.story(club, writer, null, "old content");
+                        ReflectionTestUtils.setField(post, "postId", postId);
+
+                        given(postRepository.findByPostIdAndClub_ClubId(postId, clubId))
+                                        .willReturn(Optional.of(post));
+
+                        willThrow(new ClubException.AuthNoPermission()) // 프로젝트 예외로 교체
+                                        .given(clubAuthorizationService)
+                                        .assertAtLeastManager(clubId, actorId);
+
+                        StoryUpdateRequest request = new StoryUpdateRequest(
+                                        "new content", null, null, null);
+
+                        // when & then
+                        assertThatThrownBy(() -> postService.updatePost(clubId, postId, actorId, request))
+                                        .isInstanceOf(ClubException.class);
+
+                        then(postImageRepository).shouldHaveNoInteractions();
+                        then(postMemberTagRepository).shouldHaveNoInteractions();
+                }
+
+                @Test
+                @DisplayName("[MEMBER] 모임 게시글 수정 실패 - 게시글 수정 권한 없음, 작성자 아님")
+                void update_post_member_not_writer() {
+                        // given
+                        Long clubId = 1L;
+                        Long postId = 10L;
+                        Long writerId = 100L;
+                        Long memberId = 200L; // writer 아님
+
+                        Clubs club = club(clubId);
+                        Users writer = user(writerId);
+
+                        Posts post = Posts.story(club, writer, null, "old content");
+                        ReflectionTestUtils.setField(post, "postId", postId);
+
+                        given(postRepository.findByPostIdAndClub_ClubId(postId, clubId))
+                                        .willReturn(Optional.of(post));
+
+                        willThrow(new ClubException.AuthLoginRequired()) // 프로젝트 예외로 교체
+                                        .given(clubAuthorizationService)
+                                        .assertAtLeastManager(clubId, memberId);
+
+                        List<String> imagesUrl = List.of("example/1", "example/2");
+                        StoryUpdateRequest request = new StoryUpdateRequest(
+                                        "new content", imagesUrl, null, null);
+
+                        // when & then
+                        assertThatThrownBy(() -> postService.updatePost(clubId, postId, memberId, request))
+                                        .isInstanceOf(ClubException.class);
+
+                        then(postImageRepository).shouldHaveNoInteractions();
+                        then(postMemberTagRepository).shouldHaveNoInteractions();
+                }
+
+                // ===== 테스트 헬퍼 (테스트 클래스에 이미 있으면 재사용) =====
+
+                private Clubs club(Long id) {
+                        Clubs c = newEntity(Clubs.class);
+                        ReflectionTestUtils.setField(c, "clubId", id);
+                        return c;
+                }
+
+                private Users user(Long id) {
+                        Users u = newEntity(Users.class);
+                        ReflectionTestUtils.setField(u, "userId", id);
+                        return u;
+                }
+
+                private static <T> T newEntity(Class<T> type) {
+                        try {
+                                var ctor = type.getDeclaredConstructor();
+                                ctor.setAccessible(true);
+                                return ctor.newInstance();
+                        } catch (Exception e) {
+                                throw new RuntimeException(e);
+                        }
+                }
+
+                @Nested
+                class UpdateComment {
+
+                        @Test
+                        @DisplayName("[MEMBER] 댓글 수정 성공 - 작성자")
+                        void update_comment_writer_success() {
+                                // given
+                                Long clubId = 1L;
+                                Long postId = 10L;
+                                Long commentId = 100L;
+                                Long writerId = 7L;
+
+                                PostCommentRequest req = new PostCommentRequest("updated");
+
+                                Users writer = newEntity(Users.class);
+                                ReflectionTestUtils.setField(writer, "userId", writerId);
+
+                                Posts post = newEntity(Posts.class);
+                                Comments comment = newEntity(Comments.class);
+                                ReflectionTestUtils.setField(comment, "commentId", commentId);
+                                ReflectionTestUtils.setField(comment, "post", post);
+                                ReflectionTestUtils.setField(comment, "writer", writer);
+                                ReflectionTestUtils.setField(comment, "content", "old");
+                                ReflectionTestUtils.setField(comment, "deletedAt", null);
+
+                                given(postCommentRepository
+                                                .findByCommentIdAndPost_PostIdAndPost_Club_ClubIdAndDeletedAtIsNull(
+                                                                commentId, postId, clubId))
+                                                .willReturn(Optional.of(comment));
+
+                                // when
+                                PostCommentsIdResponse res = postCommentService.updateComment(writerId, clubId, postId,
+                                                commentId, req);
+
+                                // then
+                                assertThat(res.commentId()).isEqualTo(commentId);
+                                assertThat(comment.getContent()).isEqualTo("updated");
+                                verify(clubAuthorizationService).validateAndGetClubForUpdatePosts(anyLong(),
+                                                eq(writerId));
+                                verifyNoMoreInteractions(clubAuthorizationService);
+                        }
+
+                        @Test
+                        @DisplayName("[ADMIN] 댓글 수정 성공 - 작성자 아님, 운영진 이상")
+                        void update_comment_manager_success() {
+                                // given
+                                Long clubId = 1L;
+                                Long postId = 10L;
+                                Long commentId = 100L;
+                                Long writerId = 7L;
+                                Long managerId = 8L;
+
+                                PostCommentRequest req = new PostCommentRequest("updated");
+
+                                Users writer = newEntity(Users.class);
+                                ReflectionTestUtils.setField(writer, "userId", writerId);
+
+                                Comments comment = newEntity(Comments.class);
+                                ReflectionTestUtils.setField(comment, "commentId", commentId);
+                                ReflectionTestUtils.setField(comment, "writer", writer);
+                                ReflectionTestUtils.setField(comment, "content", "old");
+                                ReflectionTestUtils.setField(comment, "deletedAt", null);
+
+                                given(postCommentRepository
+                                                .findByCommentIdAndPost_PostIdAndPost_Club_ClubIdAndDeletedAtIsNull(
+                                                                commentId, postId, clubId))
+                                                .willReturn(Optional.of(comment));
+
+                                willDoNothing().given(clubAuthorizationService)
+                                                .assertAtLeastManager(clubId, managerId);
+
+                                // when
+                                PostCommentsIdResponse res = postCommentService.updateComment(managerId, clubId, postId,
+                                                commentId, req);
+
+                                // then
+                                assertThat(res.commentId()).isEqualTo(commentId);
+                                assertThat(comment.getContent()).isEqualTo("updated");
+                                then(clubAuthorizationService).should(times(1)).assertAtLeastManager(clubId, managerId);
+                        }
+
+                        @Test
+                        @DisplayName("[MEMBER] 댓글 수정 실패 - 작성자 아님, 운영진 권한도 없음")
+                        void update_comment_forbidden() {
+                                // given
+                                Long clubId = 1L;
+                                Long postId = 10L;
+                                Long commentId = 100L;
+                                Long writerId = 7L;
+                                Long actorId = 9L;
+
+                                PostCommentRequest req = new PostCommentRequest("updated");
+
+                                Users writer = newEntity(Users.class);
+                                ReflectionTestUtils.setField(writer, "userId", writerId);
+
+                                Comments comment = newEntity(Comments.class);
+                                ReflectionTestUtils.setField(comment, "commentId", commentId);
+                                ReflectionTestUtils.setField(comment, "writer", writer);
+                                ReflectionTestUtils.setField(comment, "content", "old");
+                                ReflectionTestUtils.setField(comment, "deletedAt", null);
+
+                                given(postCommentRepository
+                                                .findByCommentIdAndPost_PostIdAndPost_Club_ClubIdAndDeletedAtIsNull(
+                                                                commentId, postId, clubId))
+                                                .willReturn(Optional.of(comment));
+
+                                willThrow(new ClubException.AuthLoginRequired()) // 프로젝트 예외로 교체
+                                                .given(clubAuthorizationService)
+                                                .assertAtLeastManager(clubId, actorId);
+
+                                // when & then
+                                assertThatThrownBy(() -> postCommentService.updateComment(actorId, clubId, postId,
+                                                commentId, req))
+                                                .isInstanceOf(ClubException.class);
+
+                                assertThat(comment.getContent()).isEqualTo("old");
+                        }
+
+                        @Test
+                        @DisplayName("댓글 수정 실패 - 이미 삭제된 댓글")
+                        void update_deleted_comment_fail() {
+                                // given
+                                Long clubId = 1L;
+                                Long postId = 10L;
+                                Long commentId = 100L;
+                                Long actorId = 7L;
+
+                                PostCommentRequest req = new PostCommentRequest("updated");
+
+                                Users writer = newEntity(Users.class);
+                                ReflectionTestUtils.setField(writer, "userId", actorId);
+
+                                Comments comment = newEntity(Comments.class);
+                                ReflectionTestUtils.setField(comment, "commentId", commentId);
+                                ReflectionTestUtils.setField(comment, "writer", writer);
+                                ReflectionTestUtils.setField(comment, "content", "old");
+                                ReflectionTestUtils.setField(comment, "deletedAt", LocalDateTime.now()); // 삭제됨
+
+                                given(postCommentRepository
+                                                .findByCommentIdAndPost_PostIdAndPost_Club_ClubIdAndDeletedAtIsNull(
+                                                                commentId, postId, clubId))
+                                                .willReturn(Optional.empty());
+
+                                assertThatThrownBy(() -> postCommentService.updateComment(actorId, clubId, postId,
+                                                commentId, req))
+                                                .isInstanceOf(PostsException.PostCommentNotFound.class); // 또는
+                                                                                                         // CommentNotFound
+                        }
+
+                        private static <T> T newEntity(Class<T> type) {
+                                try {
+                                        var ctor = type.getDeclaredConstructor();
+                                        ctor.setAccessible(true);
+                                        return ctor.newInstance();
+                                } catch (Exception e) {
+                                        throw new RuntimeException(e);
+                                }
+                        }
+                }
+
+        }
+
+        @Nested
+        class DeletePost { /* 삭제 */
+
+                @Test
+                @DisplayName("[MEMBER] 모임 게시글 삭제 성공")
+                void delete_post_member() {
+                        // given
+                        Long clubId = 1L;
+                        Long postId = 10L;
+                        Long writerId = 100L; // 작성자
+
+                        Clubs club = club(clubId);
+                        Users writer = user(writerId);
+
+                        Posts post = Posts.story(club, writer, null, "content");
+                        ReflectionTestUtils.setField(post, "postId", postId);
+
+                        given(postRepository.findByPostIdAndClub_ClubId(postId, clubId))
+                                        .willReturn(Optional.of(post));
+
+                        // when
+                        postService.deletePost(clubId, postId, writerId);
+
+                        // then
+                        assertThat(post.getDeletedAt()).isNotNull();
+
+                        // 작성자면 매니저 체크 안 탐
+                        then(clubAuthorizationService).shouldHaveNoInteractions();
+                        then(postRepository).should(times(1)).findByPostIdAndClub_ClubId(postId, clubId);
+                }
+
+                @Test
+                @DisplayName("[MEMBER] 모임 게시글 삭제 실패 - 게시글 삭제 권한 없음, 작성자 아님")
+                void delete_post_guest() {
+                        // given
+                        Long clubId = 1L;
+                        Long postId = 10L;
+                        Long writerId = 100L;
+                        Long memberId = 200L; // 작성자 아님
+
+                        Clubs club = club(clubId);
+                        Users writer = user(writerId);
+
+                        Posts post = Posts.story(club, writer, null, "content");
+                        ReflectionTestUtils.setField(post, "postId", postId);
+
+                        given(postRepository.findByPostIdAndClub_ClubId(postId, clubId))
+                                        .willReturn(Optional.of(post));
+
+                        willThrow(new ClubException.AuthLoginRequired()) // 프로젝트 예외로 교체
+                                        .given(clubAuthorizationService)
+                                        .assertAtLeastManager(clubId, memberId);
+
+                        // when & then
+                        assertThatThrownBy(() -> postService.deletePost(clubId, postId, memberId))
+                                        .isInstanceOf(ClubException.class);
+
+                        // delete 안 됨
+                        assertThat(post.getDeletedAt()).isNull();
+                        then(clubAuthorizationService).should(times(1)).assertAtLeastManager(clubId, memberId);
+                }
+
+                // ===== 테스트 헬퍼 (이미 있으면 재사용) =====
+                private Clubs club(Long id) {
+                        Clubs c = newEntity(Clubs.class);
+                        ReflectionTestUtils.setField(c, "clubId", id);
+                        return c;
+                }
+
+                private Users user(Long id) {
+                        Users u = newEntity(Users.class);
+                        ReflectionTestUtils.setField(u, "userId", id);
+                        return u;
+                }
+
+                private static <T> T newEntity(Class<T> type) {
+                        try {
+                                var ctor = type.getDeclaredConstructor();
+                                ctor.setAccessible(true);
+                                return ctor.newInstance();
+                        } catch (Exception e) {
+                                throw new RuntimeException(e);
+                        }
+                }
+
+                @Nested
+                class DeleteComment {
+
+                        @Test
+                        @DisplayName("[MEMBER] 댓글 삭제 성공 - 작성자")
+                        void delete_comment_writer_success() {
+                                // given
+                                Long clubId = 1L;
+                                Long postId = 10L;
+                                Long commentId = 100L;
+                                Long writerId = 7L;
+
+                                Users writer = newEntity(Users.class);
+                                ReflectionTestUtils.setField(writer, "userId", writerId);
+
+                                Comments comment = newEntity(Comments.class);
+                                ReflectionTestUtils.setField(comment, "commentId", commentId);
+                                ReflectionTestUtils.setField(comment, "writer", writer);
+                                ReflectionTestUtils.setField(comment, "deletedAt", null);
+
+                                given(postCommentRepository
+                                                .findByCommentIdAndPost_PostIdAndPost_Club_ClubIdAndDeletedAtIsNull(
+                                                                commentId, postId, clubId))
+                                                .willReturn(Optional.of(comment));
+
+                                // when
+                                PostCommentsIdResponse res = postCommentService.deleteComment(writerId, clubId, postId,
+                                                commentId);
+
+                                // then
+                                assertThat(res.commentId()).isEqualTo(commentId);
+                                assertThat(comment.getDeletedAt()).isNotNull(); // soft delete 확인
+                                verify(clubAuthorizationService).validateAndGetClubForUpdatePosts(anyLong(),
+                                                eq(writerId));
+                                verifyNoMoreInteractions(clubAuthorizationService);
+
+                        }
+
+                        @Test
+                        @DisplayName("[ADMIN] 댓글 삭제 성공 - 작성자 아님, 운영진 이상")
+                        void delete_comment_manager_success() {
+                                // given
+                                Long clubId = 1L;
+                                Long postId = 10L;
+                                Long commentId = 100L;
+                                Long writerId = 7L;
+                                Long managerId = 8L;
+
+                                Users writer = newEntity(Users.class);
+                                ReflectionTestUtils.setField(writer, "userId", writerId);
+
+                                Comments comment = newEntity(Comments.class);
+                                ReflectionTestUtils.setField(comment, "commentId", commentId);
+                                ReflectionTestUtils.setField(comment, "writer", writer);
+                                ReflectionTestUtils.setField(comment, "deletedAt", null);
+
+                                given(postCommentRepository
+                                                .findByCommentIdAndPost_PostIdAndPost_Club_ClubIdAndDeletedAtIsNull(
+                                                                commentId, postId, clubId))
+                                                .willReturn(Optional.of(comment));
+
+                                willDoNothing().given(clubAuthorizationService)
+                                                .assertAtLeastManager(clubId, managerId);
+
+                                // when
+                                PostCommentsIdResponse res = postCommentService.deleteComment(managerId, clubId, postId,
+                                                commentId);
+
+                                // then
+                                assertThat(res.commentId()).isEqualTo(commentId);
+                                assertThat(comment.getDeletedAt()).isNotNull();
+                                then(clubAuthorizationService).should(times(1)).assertAtLeastManager(clubId, managerId);
+                        }
+
+                        @Test
+                        @DisplayName("[MEMBER] 댓글 삭제 실패 - 작성자 아님, 운영진 권한도 없음")
+                        void delete_comment_forbidden() {
+                                // given
+                                Long clubId = 1L;
+                                Long postId = 10L;
+                                Long commentId = 100L;
+                                Long writerId = 7L;
+                                Long actorId = 9L;
+
+                                Users writer = newEntity(Users.class);
+                                ReflectionTestUtils.setField(writer, "userId", writerId);
+
+                                Comments comment = newEntity(Comments.class);
+                                ReflectionTestUtils.setField(comment, "commentId", commentId);
+                                ReflectionTestUtils.setField(comment, "writer", writer);
+                                ReflectionTestUtils.setField(comment, "deletedAt", null);
+
+                                given(postCommentRepository
+                                                .findByCommentIdAndPost_PostIdAndPost_Club_ClubIdAndDeletedAtIsNull(
+                                                                commentId, postId, clubId))
+                                                .willReturn(Optional.of(comment));
+
+                                willThrow(new ClubException.AuthLoginRequired()) // 프로젝트 예외로 교체
+                                                .given(clubAuthorizationService)
+                                                .assertAtLeastManager(clubId, actorId);
+
+                                // when & then
+                                assertThatThrownBy(() -> postCommentService.deleteComment(actorId, clubId, postId,
+                                                commentId))
+                                                .isInstanceOf(ClubException.class);
+
+                                assertThat(comment.getDeletedAt()).isNull(); // 삭제 안 됨
+                        }
+
+                        @Test
+                        @DisplayName("댓글 삭제 멱등 - 이미 삭제된 댓글은 다시 삭제해도 성공")
+                        void delete_comment_idempotent_when_already_deleted() {
+                                // given
+                                Long clubId = 1L;
+                                Long postId = 10L;
+                                Long commentId = 100L;
+                                Long actorId = 7L;
+
+                                Users writer = newEntity(Users.class);
+                                ReflectionTestUtils.setField(writer, "userId", 999L); // actor가 작성자 아니어도 상관 없음(이미 삭제면
+                                                                                      // return)
+
+                                Comments comment = newEntity(Comments.class);
+                                ReflectionTestUtils.setField(comment, "commentId", commentId);
+                                ReflectionTestUtils.setField(comment, "writer", writer);
+                                ReflectionTestUtils.setField(comment, "deletedAt", LocalDateTime.now()); // 이미 삭제됨
+
+                                given(postCommentRepository
+                                                .findByCommentIdAndPost_PostIdAndPost_Club_ClubIdAndDeletedAtIsNull(
+                                                                commentId, postId, clubId))
+                                                .willReturn(Optional.of(comment));
+
+                                // when
+                                PostCommentsIdResponse res = postCommentService.deleteComment(actorId, clubId, postId,
+                                                commentId);
+
+                                // then
+                                assertThat(res.commentId()).isEqualTo(commentId);
+                                then(clubAuthorizationService).shouldHaveNoInteractions(); // 멱등 return이라 권한 체크 안 타는 게
+                                                                                           // 깔끔
+                        }
+
+                        private static <T> T newEntity(Class<T> type) {
+                                try {
+                                        var ctor = type.getDeclaredConstructor();
+                                        ctor.setAccessible(true);
+                                        return ctor.newInstance();
+                                } catch (Exception e) {
+                                        throw new RuntimeException(e);
+                                }
+                        }
+                }
+        }
 }


### PR DESCRIPTION
## 😉 연관 이슈
#81 
## 🚀 작업 내용
- 알림 타입(NotificationType) Enum 도입으로 관리 체계화 (일정, 게시글, 댓글, 가입환영, 투표마감)
- 게시글 및 댓글 작성 시 알림 이벤트 발행 및 리스너 로직 구현 (본인 제외 필터링 적용)
- 모임 가입 승인 시 환영 알림 기능 추가 구현
- 투표 마감 1시간 전 자동 알림을 위한 스케줄러 및 조회 쿼리 구현
- 알림 리스너 전면 개선 (더미 데이터 제거 및 실제 모임원 조회 로직 연동)
- 알림 로직 검증을 위한 테스트 코드 작성 및 통과
## 💬 리뷰 중점사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 클럽 알림 전송 강화: 일정 등록, 게시글 작성, 댓글 작성, 투표 마감 임박, 가입 환영 등 다양한 이벤트에 따른 알림 자동 생성 및 발송
  * 투표 마감 알림 스케줄러: 마감 1시간 전 대상 회원들에게 자동 알림 전송

* **동작 개선**
  * 댓글 알림에서 작성자에게 불필요한 중복 알림 방지
  * 일정·게시글 알림 시 작성자 제외 처리

* **테스트**
  * 알림 처리 로직에 대한 단위 테스트 추가 (다양한 시나리오 검증)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->